### PR TITLE
Remove libgodot until the build is fixed

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -47,4 +47,4 @@ runs:
       with:
         repository: v-sekai/godot
         path: godot
-        ref: c09ab23bc5a4ce8f560ac891b0a8cf5b1509d2b3
+        ref: efc62b1a9c613b219f2f83f968d37acedb84911d

--- a/.github/workflows/vsk_linux_builds.yml
+++ b/.github/workflows/vsk_linux_builds.yml
@@ -31,17 +31,6 @@ jobs:
             artifact: true
             platform: linuxbsd
 
-          - name: Editor Linux Libgodot (target=editor)
-            cache-name: linux-editor-shared-library
-            target: editor
-            tests: false
-            sconsflags: use_llvm=yes custom_modules=../vsk_modules precision=double linker=gold deprecate=no library_type=shared_library
-            doc-test: false
-            bin: "./bin/libgodot.linuxbsd.editor.double.x86_64.llvm.so"
-            proj-conv: false
-            artifact: true
-            platform: linuxbsd
-
           - name: Editor Windows (target=editor)
             cache-name: windows-editor
             target: editor
@@ -49,17 +38,6 @@ jobs:
             sconsflags: use_llvm=yes use_mingw=yes custom_modules=../vsk_modules precision=double deprecate=no
             doc-test: false
             bin: "./bin/godot.windows.editor.double.x86_64.llvm.exe"
-            proj-conv: false
-            artifact: true
-            platform: windows
-
-          - name: Editor Windows Libgodot (target=editor)
-            cache-name: windows-editor-shared-library
-            target: editor
-            tests: false
-            sconsflags: use_llvm=yes use_mingw=yes custom_modules=../vsk_modules precision=double linker=gold deprecate=no library_type=shared_library
-            doc-test: false
-            bin: "./bin/godot.windows.editor.double.x86_64.llvm.dll"
             proj-conv: false
             artifact: true
             platform: windows
@@ -224,7 +202,6 @@ jobs:
         if: ${{ matrix.artifact }}
         run: |
           chmod +x godot/bin/godot.* || true
-          chmod +x godot/bin/libgodot.* || true
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
@@ -284,13 +261,6 @@ jobs:
           workflow_conclusion: success
           name: linux-editor
 
-      - name: Download linux-editor-shared-library artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: vsk_linux_builds.yml
-          workflow_conclusion: success
-          name: linux-editor-shared-library
-
       - name: Generate build constants
         uses: ./.github/actions/vsk-generate-constants
 
@@ -307,7 +277,6 @@ jobs:
         with:
           name: v_sekai_game_linux_x86_64
           path: |
-            libgodot.linuxbsd.editor.double.x86_64.llvm.so
             v_sekai_linux.x86_64
             v_sekai_linux.x86_64.pck
             .itch.toml
@@ -346,13 +315,6 @@ jobs:
           workflow_conclusion: success
           name: windows-editor
 
-      - name: Download windows-editor-shared-library artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: vsk_linux_builds.yml
-          workflow_conclusion: success
-          name: windows-editor-shared-library
-
       - name: Generate build constants
         uses: ./.github/actions/vsk-generate-constants
 
@@ -360,7 +322,6 @@ jobs:
         run: |
           mkdir -p .godot/editor .godot/imported export_windows
           cp godot.windows.editor.double.x86_64.llvm.exe v_sekai_windows_x86_64.exe
-          cp libgodot.windows.editor.double.x86_64.llvm.so libgodot.windows.editor.double.x86_64.llvm.dll
           chmod +x godot.linuxbsd.editor.double.x86_64.llvm
           ./godot.linuxbsd.editor.double.x86_64.llvm --headless --xr-mode off --export-pack Windows\ Desktop `pwd`/v_sekai_windows_x86_64.pck --path .
           ./godot.linuxbsd.editor.double.x86_64.llvm --headless --xr-mode off --dump-extension-api --dump-gdextension-interface
@@ -370,7 +331,6 @@ jobs:
         with:
           name: v_sekai_game_windows_x86_64
           path: |
-            libgodot.windows.editor.double.x86_64.llvm.dll
             v_sekai_windows_x86_64.exe
             v_sekai_windows_x86_64.pck
             .itch.toml


### PR DESCRIPTION
Needed to keep the builds green.

- [x] Release the build of Godot Engine as groups-4.x