### PR TITLE
Add Linux editor deployment for Windows and Linux platforms

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor Linux (target=editor,deploy=true,deploy-platform=windows,deploy-platform-target=template_release)
+          - name: linux_editor_win_deploy
             cache-name: linux-editor-deploy-windows-editor
             target: editor
             tests: false
@@ -38,7 +38,7 @@ jobs:
             deploy-platform: windows
             deploy-platform-target: editor
 
-          - name: Editor Linux (target=editor,deploy=true,deploy-platform=linux,deploy-platform-target=template_release)
+          - name: linux_editor_linux_deploy
             cache-name: linux-editor-deploy-linux-editor
             target: editor
             tests: false


### PR DESCRIPTION
This commit adds new jobs to the builds.yml file for deploying the Linux editor on both Windows and Linux platforms. The deployments include specific configurations and paths for each platform.