### PR TITLE
Update builds.yml: limit timeout for Linux export

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes 
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   EM_VERSION: 3.1.18
@@ -123,6 +123,8 @@ jobs:
           mkdir -p .godot/editor .godot/imported export_linux
           chmod +x ${{ matrix.bin }}
           ${{ matrix.bin }} --headless --xr-mode off --export-pack Linux  `pwd`/vsekai_game_${{ matrix.deploy-platform }}.pck --path .
+        timeout-minutes: 10
+
       - name: Prepare artifacts
         if: ${{ matrix.deploy && matrix.deploy-platform == 'windows' }}
         run: |


### PR DESCRIPTION
Add an export step timeout for exporting because sometime it hangs.