### PR TITLE
Update Godot dependency reference to groups-4.x.2023-07-08T190946Z

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -31,4 +31,4 @@ runs:
       with:
         repository: v-sekai/godot
         path: godot
-        ref: groups-4.x.2023-07-01T170414Z
+        ref: groups-4.x.2023-07-08T190946Z


### PR DESCRIPTION
The code changes update the reference to the Godot dependency in the action.yml file from groups-4.x.2023-07-01T170414Z to groups-4.x.2023-07-08T190946Z.