### PR TITLE
Update Godot to be groups-4.2.2023-07-23T155335Z

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -31,4 +31,4 @@ runs:
       with:
         repository: v-sekai/godot
         path: godot
-        ref: groups-4.1.2023-07-21T031218Z
+        ref: groups-4.2.2023-07-23T155335Z


### PR DESCRIPTION
Still working on a Godot Engine 4.2 migration. Documentation xml changed incompatibility. 

Posted a fix for the magenta viewport copy of xr bug. `https://github.com/godotengine/godot/issues/66247#issuecomment-1646756995`

Also works on the mac after the fix. 

One more thing, compatibility opengl mode works too on the mac.