### PR TITLE
Update Godot dependency reference

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -31,4 +31,4 @@ runs:
       with:
         repository: v-sekai/godot
         path: godot
-        ref: groups-4.2.2023-07-23T155335Z
+        ref: groups-4.2.2023-07-24T041040Z


### PR DESCRIPTION
The Godot dependency reference has been updated to "groups-4.2.2023-07-24T041040Z" in the GitHub Actions configuration file.