### PR TITLE
Update the groups groups-4.2.2023-09-12T231311Z.

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -31,4 +31,4 @@ runs:
       with:
         repository: v-sekai/godot
         path: godot
-        ref: groups-4.2.2023-08-30T150424Z
+        ref: groups-4.2.2023-09-12T231311Z


### PR DESCRIPTION
- [x] Update the godot engine version
- [ ] Start from v0.1.0-alpha1
- [ ] Publish an editor, and a vr build for Linux and Windows 