### PR TITLE
Add GitHub token for release creation

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -105,3 +105,4 @@ jobs:
           draft: true
           prerelease: true
           append_body: true
+          token: ${{ secrets.VSEKAI_GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds the necessary code to include the GitHub token for creating releases. This will allow the workflow to successfully create draft and pre-release versions of the project.