### PR TITLE
Update GitHub token in builds.yml

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -320,4 +320,4 @@ jobs:
           prerelease: true
           append_body: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VSEKAI_GITHUB_TOKEN }}


### PR DESCRIPTION
The commit updates the GitHub token used in the builds.yml file. The previous token has been replaced with a new one named VSEKAI_GITHUB_TOKEN. This change ensures that the correct token is used for authentication during the build process.