### PR TITLE
Return to previous menu when ui_cancel is pressed

### DIFF
--- a/addons/vsk_manager/vsk_game_flow_manager.gd
+++ b/addons/vsk_manager/vsk_game_flow_manager.gd
@@ -645,8 +645,6 @@ func _input(p_event: InputEvent) -> void:
 
 	if p_event.is_action_released("ui_cancel") and gameflow_state == GAMEFLOW_STATE_INGAME:
 		await go_to_title(false)
-	elif p_event.is_action_released("ui_cancel") and gameflow_state == GAMEFLOW_STATE_TITLE:
-		await go_to_title(false)
 
 	# Send input events to game viewport
 	if game_viewport:

--- a/addons/vsk_menu/menu_view_controller.gd
+++ b/addons/vsk_menu/menu_view_controller.gd
@@ -7,6 +7,10 @@ extends "res://addons/navigation_controller/view_controller.gd"
 
 @export var default_focus: NodePath
 
+func _input(event):
+	if Input.is_action_just_pressed("ui_cancel"):
+		if has_navigation_controller() and get_navigation_controller().view_controller_stack.size() > 1:
+			back_button_pressed()
 
 func back_button_pressed():
 	if has_navigation_controller():


### PR DESCRIPTION
Added an input event on the menu view controller so that, when `ui_cancel` is pressed, it calls `back_button_pressed()`.
It also checks for `view_controller_stack`'s size so that I don't accidentally destroy the title screen.

I also removed some code on the game flow manager that felt redundant, as it only returned to the title screen while already being there.

Closes #251