### PR TITLE
Update builds.yml to use groups-4.2.2023-11-29T013556Z

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   GAME_NAME: vsekai_game_
-  GODOT_REF: groups-4.2.2023-11-27T164259Z
+  GODOT_REF: groups-4.2.2023-11-29T013556Z
   GODOT_REPOSITORY: v-sekai/godot
   SCONSFLAGS: verbose=yes warnings=extra werror=no module_text_server_fb_enabled=yes use_thinlto=yes
   DOTNET_NOLOGO: true


### PR DESCRIPTION
Use [groups-4.2.2023-11-29T013556Z](https://github.com/V-Sekai/godot/releases/tag/groups-4.2.2023-11-29T013556Z)