### PR TITLE
Add Linux editor deployment configurations for Android ARM32, ARM64, …

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -87,6 +87,82 @@ jobs:
             export-platform: Mac
             arch: _x86_64
             deploy-platform-target: editor
+
+          - name: linux_editor_android_arm32_deploy
+            runs-on: ubuntu-22.04
+            cache-name: linux-editor-deploy-android-arm32-editor
+            target: editor
+            tests: false
+            sconsflags: platform=android arch=arm32 production=yes precision=double
+            doc-test: false
+            bin: ./godot/bin/godot.android.editor.arm32
+            deploy-bin: ./godot/bin/godot.android.editor.arm32
+            editor-bin-name: godot.android.editor.arm32
+            proj-conv: false
+            artifact: true
+            platform: android
+            deploy: true
+            deploy-platform: android
+            export-platform: Android
+            arch: arm32
+            deploy-platform-target: editor
+
+          - name: linux_editor_android_arm64_deploy
+            runs-on: ubuntu-22.04
+            cache-name: linux-editor-deploy-android-arm64-editor
+            target: editor
+            tests: false
+            sconsflags: platform=android arch=arm64 production=yes precision=double
+            doc-test: false
+            bin: ./godot/bin/godot.android.editor.arm64
+            deploy-bin: ./godot/bin/godot.android.editor.arm64
+            editor-bin-name: godot.android.editor.arm64
+            proj-conv: false
+            artifact: true
+            platform: android
+            deploy: true
+            deploy-platform: android
+            export-platform: Android
+            arch: arm64
+            deploy-platform-target: editor
+
+          - name: linux_editor_android_x86_32_deploy
+            runs-on: ubuntu-22.04
+            cache-name: linux-editor-deploy-android-x86_32-editor
+            target: editor
+            tests: false
+            sconsflags: platform=android arch=x86_32 production=yes precision=double
+            doc-test: false
+            bin: ./godot/bin/godot.android.editor.x86_32
+            deploy-bin: ./godot/bin/godot.android.editor.x86_32
+            editor-bin-name: godot.android.editor.x86_32
+            proj-conv: false
+            artifact: true
+            platform: android
+            deploy: true
+            deploy-platform: android
+            export-platform: Android
+            arch: x86_32
+            deploy-platform-target: editor
+
+          - name: linux_editor_android_x86_64_deploy
+            runs-on: ubuntu-22.04
+            cache-name: linux-editor-deploy-android-x86_64-editor
+            target: editor
+            tests: false
+            sconsflags: platform=android arch=x86_64 production=yes precision=double
+            doc-test: false
+            bin: ./godot/bin/godot.android.editor.x86_64
+            deploy-bin: ./godot/bin/godot.android.editor.x86_64
+            editor-bin-name: godot.android.editor.x86_64
+            proj-conv: false
+            artifact: true
+            platform: android
+            deploy: true
+            deploy-platform: android
+            export-platform: Android
+            arch: x86_64
+            deploy-platform-target: editor
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -95,9 +95,9 @@ jobs:
             tests: false
             sconsflags: platform=android arch=arm32 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/godot.android.editor.arm32
-            deploy-bin: ./godot/bin/godot.android.editor.arm32
-            editor-bin-name: godot.android.editor.arm32
+            bin: ./godot/bin/libgodot.android.editor.double.arm32.so
+            deploy-bin: ./godot/bin/libgodot.android.editor.double.arm32.so
+            editor-bin-name: libgodot.android.editor.double.arm32.so
             proj-conv: false
             artifact: true
             platform: android
@@ -114,9 +114,9 @@ jobs:
             tests: false
             sconsflags: platform=android arch=arm64 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/godot.android.editor.arm64
-            deploy-bin: ./godot/bin/godot.android.editor.arm64
-            editor-bin-name: godot.android.editor.arm64
+            bin: ./godot/bin/libgodot.android.editor.double.arm64.so
+            deploy-bin: ./godot/bin/libgodot.android.editor.double.arm64.so
+            editor-bin-name: libgodot.android.editor.double.arm64.so
             proj-conv: false
             artifact: true
             platform: android
@@ -133,9 +133,9 @@ jobs:
             tests: false
             sconsflags: platform=android arch=x86_32 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/godot.android.editor.x86_32
-            deploy-bin: ./godot/bin/godot.android.editor.x86_32
-            editor-bin-name: godot.android.editor.x86_32
+            bin: ./godot/bin/libgodot.android.editor.double.x86_32.so
+            deploy-bin: ./godot/bin/libgodot.android.editor.double.x86_32.so
+            editor-bin-name: libgodot.android.editor.double.x86_32.so
             proj-conv: false
             artifact: true
             platform: android
@@ -152,9 +152,9 @@ jobs:
             tests: false
             sconsflags: platform=android arch=x86_64 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/godot.android.editor.x86_64
-            deploy-bin: ./godot/bin/godot.android.editor.x86_64
-            editor-bin-name: godot.android.editor.x86_64
+            bin: ./godot/bin/libgodot.android.editor.double.x86_64.so
+            deploy-bin: ./godot/bin/libgodot.android.editor.double.x86_64.so
+            editor-bin-name: libgodot.android.editor.double.x86_64.so
             proj-conv: false
             artifact: true
             platform: android

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -37,8 +37,10 @@ jobs:
             tests: false
             sconsflags: linker=gold precision=double use_mingw=yes
             doc-test: false
-            bin: ./godot/bin/godot.linuxbsd.editor.double.x86_64
-            deploy-bin: ./godot/bin/godot.windows.editor.double.x86_64.exe
+            bin: 
+              - ./godot/bin/godot.linuxbsd.editor.double.x86_64
+            deploy-bin: 
+              - ./godot/bin/godot.windows.editor.double.x86_64.exe
             editor-bin-name: godot.windows.editor.double.x86_64.exe
             proj-conv: false
             artifact: true
@@ -57,8 +59,10 @@ jobs:
             tests: false
             sconsflags: linker=gold precision=double use_llvm=yes
             doc-test: false
-            bin: ./godot/bin/godot.linuxbsd.editor.double.x86_64.llvm
-            deploy-bin: ./godot/bin/godot.linuxbsd.editor.double.x86_64.llvm
+            bin: 
+              - ./godot/bin/godot.linuxbsd.editor.double.x86_64.llvm
+            deploy-bin: 
+              - ./godot/bin/godot.linuxbsd.editor.double.x86_64.llvm
             editor-bin-name: godot.linuxbsd.editor.double.x86_64.llvm
             proj-conv: false
             artifact: true
@@ -76,8 +80,10 @@ jobs:
             tests: false
             sconsflags: linker=gold precision=double
             doc-test: false
-            bin: ./godot/bin/godot.macos.editor.double.x86_64
-            deploy-bin: ./godot/bin/godot.macos.editor.double.x86_64
+            bin: 
+              - ./godot/bin/godot.macos.editor.double.x86_64
+            deploy-bin: 
+              - ./godot/bin/godot.macos.editor.double.x86_64
             editor-bin-name: godot.macos.editor.double.x86_64
             proj-conv: false
             artifact: true
@@ -95,8 +101,10 @@ jobs:
             tests: false
             sconsflags: platform=android arch=arm32 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/libgodot.android.editor.double.arm32.so
-            deploy-bin: ./godot/bin/libgodot.android.editor.double.arm32.so
+            bin: 
+              - ./godot/bin/libgodot.android.editor.double.arm32.so
+            deploy-bin: 
+              - ./godot/bin/libgodot.android.editor.double.arm32.so
             editor-bin-name: libgodot.android.editor.double.arm32.so
             proj-conv: false
             artifact: true
@@ -114,8 +122,10 @@ jobs:
             tests: false
             sconsflags: platform=android arch=arm64 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/libgodot.android.editor.double.arm64.so
-            deploy-bin: ./godot/bin/libgodot.android.editor.double.arm64.so
+            bin: 
+              - ./godot/bin/libgodot.android.editor.double.arm64.so
+            deploy-bin: 
+              - ./godot/bin/libgodot.android.editor.double.arm64.so
             editor-bin-name: libgodot.android.editor.double.arm64.so
             proj-conv: false
             artifact: true
@@ -133,8 +143,10 @@ jobs:
             tests: false
             sconsflags: platform=android arch=x86_32 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/libgodot.android.editor.double.x86_32.so
-            deploy-bin: ./godot/bin/libgodot.android.editor.double.x86_32.so
+            bin: 
+              - ./godot/bin/libgodot.android.editor.double.x86_32.so
+            deploy-bin: 
+              - ./godot/bin/libgodot.android.editor.double.x86_32.so
             editor-bin-name: libgodot.android.editor.double.x86_32.so
             proj-conv: false
             artifact: true
@@ -152,8 +164,10 @@ jobs:
             tests: false
             sconsflags: platform=android arch=x86_64 production=yes precision=double
             doc-test: false
-            bin: ./godot/bin/libgodot.android.editor.double.x86_64.so
-            deploy-bin: ./godot/bin/libgodot.android.editor.double.x86_64.so
+            bin: 
+              - ./godot/bin/libgodot.android.editor.double.x86_64.so
+            deploy-bin: 
+              - ./godot/bin/libgodot.android.editor.double.x86_64.so
             editor-bin-name: libgodot.android.editor.double.x86_64.so
             proj-conv: false
             artifact: true
@@ -163,6 +177,7 @@ jobs:
             export-platform: Android
             arch: x86_64
             deploy-platform-target: editor
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -282,11 +297,13 @@ jobs:
           mkdir -p $TARGET
 
           # If deploy platform is windows, append .exe to the binary
-          if [ "${{ matrix.deploy-platform }}" == "windows" ]; then
-              cp -rf ${{ matrix.deploy-bin }} $TARGET/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}.exe
-          else
-              cp -rf ${{ matrix.deploy-bin }} $TARGET/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}
-          fi
+          for bin in ${{ matrix.deploy-bin }}; do
+              if [ "${{ matrix.deploy-platform }}" == "windows" ]; then
+                  cp -rf $bin $TARGET/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}.exe
+              else
+                  cp -rf $bin $TARGET/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}
+              fi
+          done
 
           cp -rf `pwd`/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}.pck $TARGET/${{ env.GAME_NAME }}${{ matrix.deploy-platform }}.pck
           7z a -r $TARGET.zip $TARGET
@@ -303,7 +320,7 @@ jobs:
       - name: Generate C# glue
         if: ${{ matrix.build-mono }}
         run: |
-          ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue || true
+          ${{ matrix.deploy-bin[0] }} --headless --generate-mono-glue ./modules/mono/glue || true
         shell: bash
 
       - name: Build .NET solutions


### PR DESCRIPTION
…x86_32, and x86_64.

These configurations include specific settings for each architecture to deploy the editor on Android.