### PR TITLE
Fix player_body.gd annotation

### DIFF
--- a/addons/godot-xr-tools/assets/player_body.gd
+++ b/addons/godot-xr-tools/assets/player_body.gd
@@ -1,8 +1,7 @@
 @tool
+@icon("res://addons/godot-xr-tools/editor/icons/body.svg")
 class_name XRToolsPlayerBody
 extends Node
-@icon("res://addons/godot-xr-tools/editor/icons/body.svg")
-
 
 ## XR Tools Player Physics Body Script
 ##


### PR DESCRIPTION
Fix error
`SCRIPT ERROR: Parse Error: Annotation "@icon" must be at the top of the script, before "extends" and "class_name".
          at: GDScript::reload (res://addons/godot-xr-tools/assets/player_body.gd:4)`