### PR TITLE
Fix avatar load failure on server join

### DIFF
--- a/addons/network_manager/network_replication_manager.gd
+++ b/addons/network_manager/network_replication_manager.gd
@@ -224,12 +224,16 @@ func get_network_scene_id_from_path(p_path: String) -> int:
 	var path: String = p_path
 	var network_entity_manager: Node = network_manager.network_entity_manager
 
+	var player_scene_path: String = ""
+	if ProjectSettings.has_setting("network/config/player_scene"):
+		player_scene_path = ProjectSettings.get_setting("network/config/player_scene")
+
 	while 1:
 		var network_scene_id: int = network_entity_manager.networked_scenes.find(path)
 
 		# If a valid packed scene was not found, try next to search for it via its inheritance chain
 		if network_scene_id == -1:
-			if path != "res://addons/vsk_entities/vsk_player.tscn":
+			if path != player_scene_path:
 				push_error(
 					(
 						"SECURITY: "
@@ -434,7 +438,10 @@ func get_scene_path_for_scene_id(p_scene_id: int) -> String:
 
 
 func get_packed_scene_for_path(p_path: String) -> PackedScene:
-	if p_path != "res://addons/vsk_entities/vsk_player.tscn":
+	var network_entity_manager: Node = network_manager.network_entity_manager
+	var network_scene_id: int = network_entity_manager.networked_scenes.find(p_path)
+
+	if network_scene_id == -1:  # Not found
 		push_error(
 			(
 				"SECURITY: "


### PR DESCRIPTION
When joining an existing server, game was stuck with grey screen after map load.

```
...
Client  has connected!
Adding player display name for 1...
Adding player avatar path for 1...
Instance map...
Instancing map...
Assigning instanced map...
Instanced map assigned!
Map instanced!
Decoding server state init buffer...
ERROR: Caller thread can't call this function in this node (/root/NetworkManager/NetworkReplicationManager). Use call_deferred() or call_thread_group() instead.
   at: to_string (scene/main/node.cpp:2848)
   GDScript backtrace (most recent call first):
       [0] get_packed_scene_for_path (res://addons/network_manager/network_replication_manager.gd:438)
       [1] decode_entity_spawn_command (res://addons/network_manager/network_replication_manager.gd:514)
...
ERROR: SECURITY: @/root/NetworkManager/NetworkReplicationManager: get_packed_scene_for_path at res://addons/vsk_entities/vsk_player_old.tscn
   at: push_error (core/variant/variant_utility.cpp:1024)
   GDScript backtrace (most recent call first):
       [0] get_packed_scene_for_path (res://addons/network_manager/network_replication_manager.gd:438)
       [1] decode_entity_spawn_command (res://addons/network_manager/network_replication_manager.gd:514)
...
ERROR: decode_entity_spawn_command: received invalid packed_scene for path res://addons/vsk_entities/vsk_player_old.tscn!
   at: push_error (core/variant/variant_utility.cpp:1024)
   GDScript backtrace (most recent call first):
       [0] error (res://addons/network_manager/network_logger.gd:32)
       [1] decode_entity_spawn_command (res://addons/network_manager/network_replication_manager.gd:516)
       [2] decode_replication_buffer (res://addons/network_manager/network_replication_manager.gd:689)
...
Done!
Setting current map...
Current map set!
GOT a finished signal!
confirm_server_ready_for_sync...
ERROR: Condition "!player" is true. Returning: false
   at: set_audio_input_stream_player (modules/speech/speech_processor.cpp:294)
   GDScript backtrace (most...
```


The issue was caused by `get_packed_scene_for_path()` in `addons/network_manager/network_replication_manager.gd`.
This function ran a whitelist check against unused "vsk_player.tscn" instead of expected "vsk_player_old.tscn".

This PR fixes the issue by testing against a whitelist of networked scenes set in ProjectSettings.
       