### PR TITLE
Implement new user registration API and UI logic

### DIFF
--- a/addons/godot_uro/godot_uro_api.gd
+++ b/addons/godot_uro/godot_uro_api.gd
@@ -87,7 +87,8 @@ func register_async(
 		"user[email]": p_email,
 		"user[password]": p_password,
 		"user[password_confirmation]": p_password_confirmation,
-		"user[email_notifications]": GodotUroHelper.bool_to_string(p_email_notifications)
+		"user[email_notifications]": GodotUroHelper.bool_to_string(p_email_notifications),
+		"apiKey": GodotUroHelper.SIGNUP_API_KEY
 	}
 
 	var result = await (p_requester.request(

--- a/addons/godot_uro/godot_uro_helper.gd
+++ b/addons/godot_uro/godot_uro_helper.gd
@@ -70,6 +70,7 @@ const DEFAULT_ACCOUNT_USERNAME: String = "UNKNOWN_USERNAME"
 const DEFAULT_ACCOUNT_DISPLAY_NAME: String = "UNKNOWN_DISPLAY_NAME"
 const UNTITLED_SHARD: String = "UNTITLED_SHARD"
 const UNKNOWN_MAP: String = "UNKNOWN_MAP"
+const SIGNUP_API_KEY = "eNoZ4kXHgT0z9ZTYGsq7eE0rQYvR6YBi"
 
 
 static func get_string_for_requester_code(p_requester_code: int) -> String:

--- a/addons/sar_game_framework/generic/managers/game_service_manager/sar_game_service.gd
+++ b/addons/sar_game_framework/generic/managers/game_service_manager/sar_game_service.gd
@@ -21,13 +21,16 @@ signal session_deletion_complete(p_request: SarGameServiceRequest, p_result: Dic
 static func get_service_name() -> String:
 	return "UnknownGameService"
 	
-## Attempts to sign into the service. A SarGameServiceRequestObject created
+## Attempts to sign-in/register into the service. A SarGameServiceRequestObject created
 ## from the service required to keep track of the individual request,
 ## and a Dictionary containing service-specific sign in data, should be
 ## passed in as a parameters. The method may await a coroutine,
 ## but will return a dictionary containing the result, or an empty one if
 ## the action failed outright.
 func sign_in(_service_request: SarGameServiceRequest, _sign_in_data: Dictionary) -> Dictionary:
+	return {}
+
+func register(_service_request: SarGameServiceRequest, _register_data: Dictionary) -> Dictionary:
 	return {}
 
 ## Creates a service request object. This can then be passed into

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.gd
@@ -1,3 +1,47 @@
 @tool
 extends VSKUIViewControllerAccountAction
 class_name VSKUIViewControllerRegister
+
+signal signed_up(p_result: VSKUIViewControllerRegistering.RegisterResult, p_id: String)
+
+const _REGISTERING_ACCOUNT_VIEW_CONTROLLER: PackedScene = preload("res://addons/vsk_ui/view_controllers/vsk_ui_view_controller_registering_account.tscn")
+
+@export var view_account_action: VSKUIViewAccountAction = null
+
+func _get_uro_service() -> VSKGameServiceUro:
+	var service_manager: SarGameServiceManager = get_tree().get_first_node_in_group("game_service_managers")
+	if service_manager:
+		var uro_service: VSKGameServiceUro = service_manager.get_service("Uro")
+		return uro_service
+		
+	return null
+
+func _sign_up_complete(p_result: VSKUIViewControllerRegistering.RegisterResult, p_id: String) -> void:
+	if p_result == VSKUIViewControllerRegistering.RegisterResult.OK:
+		get_navigation_controller().pop_view_controller(true)
+		
+		signed_up.emit(p_result, p_id)
+
+func _on_view_sign_up_selected() -> void:
+	var domain: String = view_account_action.get_domain()
+	var email: String = view_account_action.get_register_email()
+	var username: String = view_account_action.get_register_username()
+	var password: String = view_account_action.get_register_password()
+	var repeat_password: String = view_account_action.get_register_repeat_password()
+	var email_notifications: bool = view_account_action.get_email_notifications()
+
+	var view_controller: VSKUIViewControllerRegistering = _REGISTERING_ACCOUNT_VIEW_CONTROLLER.instantiate()
+	
+	var register_data: Dictionary = {
+		"domain":domain.to_lower(),
+		"email":email.to_lower(),
+		"username":username.to_lower(),
+		"password":password,
+		"repeat_password":repeat_password,
+		"email_notifications":email_notifications
+	}
+	
+	view_controller.register(_get_uro_service(), register_data)
+	get_navigation_controller().push_view_controller(view_controller, true)
+	
+	assert(view_controller.sign_up_complete.connect(_sign_up_complete) == OK)

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.tscn
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://din75qs526m46" path="res://addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.gd" id="1_7twhi"]
 [ext_resource type="PackedScene" uid="uid://3as8qqoehxad" path="res://addons/vsk_ui/views/vsk_ui_view_account_action.tscn" id="2_7twhi"]
 
-[node name="RegisterViewController" type="Control" node_paths=PackedStringArray("view")]
+[node name="RegisterViewController" type="Control" node_paths=PackedStringArray("view_account_action", "view")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,6 +11,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_7twhi")
+view_account_action = NodePath("MarginContainer/AspectRatioContainer/View")
 view = NodePath("MarginContainer/AspectRatioContainer/View")
 title = "Register"
 
@@ -32,3 +33,4 @@ account_action = 1
 metadata/_edit_pinned_properties_ = [&"account_action"]
 
 [connection signal="pick_other_domain_selected" from="MarginContainer/AspectRatioContainer/View" to="." method="_on_view_pick_other_domain_selected"]
+[connection signal="sign_up_selected" from="MarginContainer/AspectRatioContainer/View" to="." method="_on_view_sign_up_selected"]

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_registering_account.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_registering_account.gd
@@ -1,6 +1,77 @@
-@tool
-extends SarUIViewController
-class_name VSKUIViewControllerSelectStandingOrSeated
-
 #func _ready() -> void::
 #	GodotUro.register_async()
+
+@tool
+extends SarUIViewController
+class_name VSKUIViewControllerRegistering
+
+enum RegisterResult {
+	PENDING,
+	OK,
+	FAILED,
+}
+
+signal sign_up_complete(p_result: RegisterResult, p_id: String)
+
+var _domain: String = ""
+var _username: String = ""
+
+var _service: SarGameService = null
+var _request: SarGameServiceRequest = null
+var _register_result: RegisterResult = RegisterResult.PENDING
+
+func will_disappear() -> void:
+	if _service and _request:
+		_service.stop_request(_request)
+		
+	if _service.session_request_complete.is_connected(_session_request_complete):
+		_service.session_request_complete.disconnect(_session_request_complete)
+
+func _process_register_result() -> void:
+	if _register_result != RegisterResult.PENDING:
+		get_navigation_controller().pop_view_controller(true)
+		
+		sign_up_complete.emit(_register_result, "%s@%s" % [_username, _domain])
+
+func _session_request_complete(p_request: SarGameServiceRequest, p_result: Dictionary) -> void:
+	if not is_node_ready():
+		await ready
+	
+	if p_request != _request:
+		return
+		
+	if _service.session_request_complete.is_connected(_session_request_complete):
+		_service.session_request_complete.disconnect(_session_request_complete)
+		
+	if p_result.get("response_code", -1) == HTTPClient.RESPONSE_OK:
+		_username = p_result.get("user_username", "")
+		if not _username.is_empty():
+			_register_result = RegisterResult.OK
+		else:
+			_register_result = RegisterResult.FAILED
+	else:
+		_register_result = RegisterResult.FAILED
+		
+	_process_register_result() 
+	
+	return
+		
+func _ready() -> void:
+	super._ready()
+
+###
+
+## Call this method to request a registration with a game service.
+func register(p_game_service: SarGameService, p_register_data: Dictionary) -> void:
+	assert(_service == null)
+	assert(_request == null)
+	
+	_service = p_game_service
+	
+	assert(_service.session_request_complete.connect(_session_request_complete) == OK)
+	
+	_domain = p_register_data.get("domain", "")
+	_username = ""
+	
+	_request = p_game_service.create_request({"domain":_domain})
+	p_game_service.register(_request, p_register_data)

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_welcome.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_welcome.gd
@@ -6,12 +6,21 @@ const _LOGIN_VIEW_CONTROLLER: PackedScene = preload("res://addons/vsk_ui/view_co
 const _REGISTER_VIEW_CONTROLLER: PackedScene = preload("res://addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.tscn")
 
 signal signed_in(p_id: String)
+signal signed_up(p_id: String)
 signal skipped
 
 func _signed_in(p_result: VSKUIViewControllerLoggingIn.LogInResult, p_id: String) -> void:
 	if p_result == VSKUIViewControllerLoggingIn.LogInResult.OK:
 		get_navigation_controller().pop_view_controller(true)
 		signed_in.emit(p_id)
+
+func _signed_up(p_result: VSKUIViewControllerRegistering.RegisterResult, p_id: String) -> void:
+	if p_result == VSKUIViewControllerRegistering.RegisterResult.OK:
+		get_navigation_controller().pop_view_controller(true)
+		signed_up.emit(p_id)
+
+		# Redirect to login screen
+		_on_welcome_menu_sign_in_pressed()
 
 func _on_welcome_menu_sign_in_pressed() -> void:
 	var view_controller: VSKUIViewControllerLogin = _LOGIN_VIEW_CONTROLLER.instantiate()
@@ -20,8 +29,10 @@ func _on_welcome_menu_sign_in_pressed() -> void:
 	assert(view_controller.signed_in.connect(_signed_in) == OK)
 
 func _on_welcome_menu_register_pressed() -> void:
-	var view_controller: SarUIViewController = _REGISTER_VIEW_CONTROLLER.instantiate()
+	var view_controller: VSKUIViewControllerRegister = _REGISTER_VIEW_CONTROLLER.instantiate()
 	get_navigation_controller().push_view_controller(view_controller, true)
+
+	assert(view_controller.signed_up.connect(_signed_up) == OK)
 
 func _on_welcome_menu_skip_pressed() -> void:
 	get_navigation_controller().pop_view_controller(true)

--- a/addons/vsk_ui/views/vsk_ui_view_account_action.gd
+++ b/addons/vsk_ui/views/vsk_ui_view_account_action.gd
@@ -7,11 +7,19 @@ class_name VSKUIViewAccountAction
 @export var _sign_in_content: Control = null
 @export var _register_content: Control = null
 
+@export var _register_email_field: LineEdit = null
+@export var _register_username_field: LineEdit = null
+@export var _register_password_field: LineEdit = null
+@export var _register_repeat_password_field: LineEdit = null
+@export var _register_email_notifications_field: CheckBox = null
+@export var _register_submit_button: BaseButton = null
+
 @export var _sign_in_email_or_username_field: LineEdit = null
 @export var _sign_in_password_field: LineEdit = null
 @export var _sign_in_submit_button: BaseButton = null
 
 signal sign_in_selected
+signal sign_up_selected
 signal pick_other_domain_selected
 
 func _pick_other_domain_selected() -> void:
@@ -56,6 +64,36 @@ func _on_sign_in_password_text_changed(_new_text: String) -> void:
 
 func _on_sign_in_button_pressed() -> void:
 	sign_in_selected.emit()
+
+func _validate_register_submit_button_state() -> void:
+	if not Engine.is_editor_hint():
+		if _register_email_field.text.length() > 0 and \
+		_register_username_field.text.length() > 0 and \
+		_register_password_field.text.length() > 0 and \
+		_register_repeat_password_field.text.length() > 0 and \
+		_register_password_field.text == _register_repeat_password_field.text:
+			_register_submit_button.disabled = false
+		else:
+			_register_submit_button.disabled = true
+
+func _on_register_username_text_changed(_new_text: String) -> void:
+	if not Engine.is_editor_hint():
+		_validate_register_submit_button_state()
+
+func _on_register_email_text_changed(_new_text: String) -> void:
+	if not Engine.is_editor_hint():
+		_validate_register_submit_button_state()
+
+func _on_register_password_text_changed(_new_text: String) -> void:
+	if not Engine.is_editor_hint():
+		_validate_register_submit_button_state()
+
+func _on_register_repeat_password_text_changed(_new_text: String) -> void:
+	if not Engine.is_editor_hint():
+		_validate_register_submit_button_state()
+
+func _on_register_button_pressed() -> void:
+	sign_up_selected.emit()
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
@@ -108,4 +146,24 @@ func get_sign_in_username_or_email() -> String:
 ## Returns the text in the password sign in field.
 func get_sign_in_password() -> String:
 	return _sign_in_password_field.text
+	
+## Returns the text in the email registration field.
+func get_register_email() -> String:
+	return _register_email_field.text
+	
+## Returns the text in the username registration field.
+func get_register_username() -> String:
+	return _register_username_field.text
+	
+## Returns the text in the password registration field.
+func get_register_password() -> String:
+	return _register_password_field.text
+	
+## Returns the text in the repeat password registration field.
+func get_register_repeat_password() -> String:
+	return _register_repeat_password_field.text
+	
+## Returns the setting in the email notifications registration field.
+func get_email_notifications() -> bool:
+	return _register_email_notifications_field.button_pressed
 	

--- a/addons/vsk_ui/views/vsk_ui_view_account_action.tscn
+++ b/addons/vsk_ui/views/vsk_ui_view_account_action.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="FontFile" uid="uid://b66f6a8gfqkrc" path="res://addons/vsk_ui/fonts/ZenKakuGothicNew-Bold.ttf" id="4_cwesk"]
 [ext_resource type="PackedScene" uid="uid://cx3gwjtcd3ona" path="res://addons/vsk_ui/widgets/vsk_check_box.tscn" id="5_0qcc6"]
 
-[node name="AccountActionView" type="Control" node_paths=PackedStringArray("_action_label", "_domain_label", "_sign_in_content", "_register_content", "_sign_in_email_or_username_field", "_sign_in_password_field", "_sign_in_submit_button")]
+[node name="AccountActionView" type="Control" node_paths=PackedStringArray("_action_label", "_domain_label", "_sign_in_content", "_register_content", "_register_email_field", "_register_username_field", "_register_password_field", "_register_repeat_password_field", "_register_email_notifications_field", "_register_submit_button", "_sign_in_email_or_username_field", "_sign_in_password_field", "_sign_in_submit_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -19,6 +19,12 @@ _action_label = NodePath("VBoxContainer/InfoBox/ActionLabel")
 _domain_label = NodePath("VBoxContainer/InfoBox/DomainLabel")
 _sign_in_content = NodePath("VBoxContainer/SignInContent")
 _register_content = NodePath("VBoxContainer/RegisterContent")
+_register_email_field = NodePath("VBoxContainer/RegisterContent/SignUpEmail")
+_register_username_field = NodePath("VBoxContainer/RegisterContent/SignUpUsername")
+_register_password_field = NodePath("VBoxContainer/RegisterContent/SignUpPassword")
+_register_repeat_password_field = NodePath("VBoxContainer/RegisterContent/SignUpRepeatPassword")
+_register_email_notifications_field = NodePath("VBoxContainer/RegisterContent/VSKCheckBox")
+_register_submit_button = NodePath("VBoxContainer/RegisterContent/RegisterButton")
 _sign_in_email_or_username_field = NodePath("VBoxContainer/SignInContent/SignInEmailOrUsername")
 _sign_in_password_field = NodePath("VBoxContainer/SignInContent/SignInPassword")
 _sign_in_submit_button = NodePath("VBoxContainer/SignInContent/ButtonsContainer/TopButtons/SignInButton")
@@ -175,6 +181,7 @@ size_flags_vertical = 3
 [node name="RegisterButton" type="Button" parent="VBoxContainer/RegisterContent"]
 layout_mode = 2
 size_flags_horizontal = 3
+disabled = true
 text = "Create Account"
 
 [node name="Spacer6" type="Control" parent="VBoxContainer/RegisterContent"]
@@ -188,4 +195,9 @@ text = "Pick Another Server"
 [connection signal="text_changed" from="VBoxContainer/SignInContent/SignInEmailOrUsername" to="." method="_on_sign_in_email_or_username_text_changed"]
 [connection signal="text_changed" from="VBoxContainer/SignInContent/SignInPassword" to="." method="_on_sign_in_password_text_changed"]
 [connection signal="pressed" from="VBoxContainer/SignInContent/ButtonsContainer/TopButtons/SignInButton" to="." method="_on_sign_in_button_pressed"]
+[connection signal="text_changed" from="VBoxContainer/RegisterContent/SignUpEmail" to="." method="_on_register_email_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/RegisterContent/SignUpUsername" to="." method="_on_register_username_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/RegisterContent/SignUpPassword" to="." method="_on_register_password_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/RegisterContent/SignUpRepeatPassword" to="." method="_on_register_repeat_password_text_changed"]
+[connection signal="pressed" from="VBoxContainer/RegisterContent/RegisterButton" to="." method="_on_register_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/PickAnotherServerButton" to="." method="_pick_other_domain_selected"]

--- a/addons/vsk_ui/views/vsk_ui_view_welcome.tscn
+++ b/addons/vsk_ui/views/vsk_ui_view_welcome.tscn
@@ -47,8 +47,7 @@ size_flags_horizontal = 3
 text = "Sign-in"
 
 [node name="RegisterButton" type="Button" parent="VBoxContainer/Container/HBoxContainer"]
-editor_description = "Need to sort out the API for in-app account creation."
-visible = false
+visible = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Create Account"


### PR DESCRIPTION
This PR implements missing user sign-up logic.

API key was added since it is required in new server, see #505 
On successful registration, login screen opens.

Registration was tested on latest uro server with https://github.com/V-Sekai/uro/pull/121 applied.