### PR TITLE
Fix input component skipping one-off keyboard events

### DIFF
--- a/addons/sar_game_framework/generic/souls/components/sar_soul_player_commands_component.gd
+++ b/addons/sar_game_framework/generic/souls/components/sar_soul_player_commands_component.gd
@@ -2,22 +2,39 @@
 extends Node
 class_name SarSoulPlayerCommandsComponent
 
-## This component is respnosible for taking a list of named commands
+## This component is responsible for taking a list of named commands
 ## from the global Input singleton and translating them to the possessed
 ## entity's input component.
 
-func _process(_delta: float) -> void:
+var active_commands: Dictionary = {}
+
+func _input(p_event: InputEvent) -> void:
 	if not Engine.is_editor_hint() and is_multiplayer_authority():
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel:
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
 			assert(input_component)
-			
-			for command: String in commands:
-				if InputMap.has_action(command):
-					input_component.set_input_value_for_action(command, Input.get_action_strength(command))
 
-###
+			# Workaround to persist action for one _process() frame in SarGameEntityComponentVesselInput _input_table
+			# This is needed because _input_table is processed with _physics_process() -> _update_input() in VSKPlayerSimulationInputComponent
+			for command: String in commands:
+				if InputMap.has_action(command) and p_event.is_action_pressed(command) and not p_event.is_echo():
+					var strength = Input.get_action_strength(command)
+					active_commands[command] = {"time": Time.get_ticks_usec() / 1_000_000.0, "strength": strength}
+					input_component.set_input_value_for_action(command, strength)
+
+func _physics_process(delta: float):
+	if not Engine.is_editor_hint() and is_multiplayer_authority():
+		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
+		if vessel:
+			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
+			assert(input_component)
+			var time = Time.get_ticks_usec() / 1_000_000.0
+			for command in active_commands:
+					var trigger_time = active_commands[command].get("time")
+					if time > (trigger_time + delta):
+						input_component.set_input_value_for_action(command, 0.0)
+						active_commands.erase(command)
 
 ## A list of commands to translate to the posssessed entity's input component.
 @export var commands: Array[String] = []


### PR DESCRIPTION
Input component sometimes skipped one-off keyboard actions due to usage of `_process()`. As an example pressing Escape key did not always open menu.

This PR is a quick-fix to process commands with `_input()` instead and persist them for at least one `_physics_process()` frame.