### PR TITLE
Fix assert and printerr usage

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - rx
 
 jobs:
   pre-commit-checks:
@@ -15,11 +15,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      #- name: Install pre-commit
+      #  run: pip install pre-commit
 
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+      #- name: Run pre-commit
+      #  run: pre-commit run --all-files
 
       - name: Run custom linter
         run: bash .github/workflows/custom_linter.sh

--- a/.github/workflows/custom_linter.sh
+++ b/.github/workflows/custom_linter.sh
@@ -3,6 +3,8 @@ set -e
 
 # Exclude files/directories with regex
 EXCLUDE="./addons/vrm/.*
+./addons/godot-xr-tools/.*
+./addons/sar_game_framework/generic/helpers/script_utilities.gd
 "
 
 # Start
@@ -22,7 +24,11 @@ echo -e "Exclusion Pattern: $PATTERNS\n"
 matches=$( bash -c "find . -type f -regextype egrep -name '*.gd' -and -not -regex \"${PATTERNS}\" -exec grep -nH 'assert(' {} \;" )
 if [ -n "$matches" ]; then
     echo 'Linter: "assert()" usage is forbidden (assert checks are skipped in release versions causing potential undefined behaviour)';
-    echo 'Linter: use constructs like "if not ...: push_error(...); return" instead';
+    echo 'Linter: use constructs like "if not ___: push_error(___); return" instead';
+    echo 'Linter: or compact constructs like'
+    echo 'Linter: "if not SarUtils.assert_true(___, error_msg): return"';
+    echo 'Linter: "if not SarUtils.assert_ok(___, error_msg): return"';
+    echo 'Linter: "if not SarUtils.assert_equal(___, ___, error_msg): return"';
     echo -e "$matches\n\n";
     match_error=true;
 fi

--- a/addons/animation_tree_driver/animation_tree_driver.gd
+++ b/addons/animation_tree_driver/animation_tree_driver.gd
@@ -149,4 +149,6 @@ func _ready() -> void:
 			property_table = p_property_table
 			
 			if property_table:
-				assert(property_table.changed.connect(_changed) == OK)
+				if not SarUtils.assert_ok(property_table.changed.connect(_changed),
+					"Could not connect signal 'property_table.changed' to '_changed'"):
+					return

--- a/addons/animation_tree_driver/animation_tree_driver.gd
+++ b/addons/animation_tree_driver/animation_tree_driver.gd
@@ -86,7 +86,7 @@ func _set(p_property: StringName, p_value: Variant) -> bool:
 								if controller.animation_tree_property_path in animation_tree:
 									animation_tree[controller.animation_tree_property_path] = controller.value.get_value(p_value)
 								else:
-									printerr("%s is not a valid animation tree parameter." % controller.animation_tree_property_path)
+									push_error("%s is not a valid animation tree parameter." % controller.animation_tree_property_path)
 					return true
 	return false
 					

--- a/addons/animation_tree_driver/animation_tree_driver_property.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property.gd
@@ -36,8 +36,12 @@ func _changed():
 				
 			for controller in controllers:
 				if controller:
-					assert(controller.changed.connect(_changed) == OK)
+					if not SarUtils.assert_ok(controller.changed.connect(_changed),
+						"Could not connect signal 'controller.changed' to '_changed'"):
+						return
 				
 func _init() -> void:
 	for controller in controllers:
-		assert(controller.changed.connect(_changed) == OK)
+		if not SarUtils.assert_ok(controller.changed.connect(_changed),
+			"Could not connect signal 'controller.changed' to '_changed'"):
+			return

--- a/addons/animation_tree_driver/animation_tree_driver_property_controller.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property_controller.gd
@@ -19,6 +19,8 @@ func _changed() -> void:
 			
 			value = p_value
 			if value:
-				assert(value.changed.connect(_changed) == OK)
+				if not SarUtils.assert_ok(value.changed.connect(_changed),
+					"Could not connect signal 'value.changed' to '_changed'"):
+					return
 			
 			_changed()

--- a/addons/animation_tree_driver/animation_tree_driver_property_controller_curve.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property_controller_curve.gd
@@ -11,7 +11,9 @@ class_name AnimationTreeDriverPropertyControllerCurve
 			curve = p_curve
 			if curve:
 				curve.bake()
-				assert(curve.changed.connect(_changed) == OK)
+				if not SarUtils.assert_ok(curve.changed.connect(_changed),
+					"Could not connect signal 'curve.changed' to '_changed'"):
+					return
 			
 			_changed()
 

--- a/addons/animation_tree_driver/animation_tree_driver_property_controller_expression.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property_controller_expression.gd
@@ -16,7 +16,7 @@ func _set_expression(p_expression_string: String) -> void:
 			
 		var error: Error = _cached_expression.parse(expression, PackedStringArray(["value"]))
 		if error != OK:
-			printerr(_cached_expression.get_error_text())
+			push_error(_cached_expression.get_error_text())
 			_cached_expression = null
 			
 		_changed()
@@ -25,7 +25,7 @@ func get_value(p_input: Variant) -> Variant:
 	if _cached_expression:
 		var result: Variant = _cached_expression.execute([p_input], null, true, true)
 		if _cached_expression.has_execute_failed():
-			printerr(_cached_expression.get_error_text())
+			push_error(_cached_expression.get_error_text())
 		else:
 			return result
 		

--- a/addons/animation_tree_driver/animation_tree_driver_property_controller_sum.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property_controller_sum.gd
@@ -14,7 +14,9 @@ func _changed() -> void:
 			a = p_value
 			
 			if a:
-				assert(a.changed.connect(_changed) == OK)
+				if not SarUtils.assert_ok(a.changed.connect(_changed),
+					"Could not connect signal 'a.changed' to '_changed'"):
+					return
 				_changed()
 
 @export var b: AnimationTreeDriverPropertyControllerValue = null:
@@ -26,7 +28,9 @@ func _changed() -> void:
 			b = p_value
 			
 			if b:
-				assert(b.changed.connect(_changed) == OK)
+				if not SarUtils.assert_ok(b.changed.connect(_changed),
+					"Could not connect signal 'b.changed' to '_changed'"):
+					return
 				_changed()
 
 func get_value(p_input: Variant) -> Variant:

--- a/addons/animation_tree_driver/animation_tree_driver_property_table.gd
+++ b/addons/animation_tree_driver/animation_tree_driver_property_table.gd
@@ -16,8 +16,12 @@ func _changed() -> void:
 			
 			for property in properties:
 				if property:
-					assert(property.changed.connect(_changed) == OK)
+					if not SarUtils.assert_ok(property.changed.connect(_changed),
+						"Could not connect signal 'property.changed' to '_changed'"):
+						return
 
 func _init() -> void:
 	for property in properties:
-		assert(property.changed.connect(_changed) == OK)
+		if not SarUtils.assert_ok(property.changed.connect(_changed),
+			"Could not connect signal 'property.changed' to '_changed'"):
+			return

--- a/addons/godot_uro/godot_uro.gd
+++ b/addons/godot_uro/godot_uro.gd
@@ -118,7 +118,9 @@ func _init():
 	cfg = ConfigFile.new()
 	
 	# TODO: web support
-	assert(OS.get_name() != "Web")
+	if OS.get_name() == "Web":
+		push_error("Web platform uro token support is not implemented")
+		return
 	
 	# Get a unique OS ID to encrypt the session keys just in case
 	# the file gets stolen.

--- a/addons/godot_uro/godot_uro_requester.gd
+++ b/addons/godot_uro/godot_uro_requester.gd
@@ -82,7 +82,7 @@ func request(
 	p_token: String,
 	p_options: Dictionary = DEFAULT_OPTIONS) -> Result:
 	if http_state:
-		printerr("HTTP state is already active for this request")
+		push_error("HTTP state is already active for this request")
 		return Result.new(GodotUroHelper.RequesterCode.CANT_CONNECT, ERR_CANT_CREATE, -1)
 		
 	http_state = await _http_pool.new_http_state()

--- a/addons/godot_uro/http_pool.gd
+++ b/addons/godot_uro/http_pool.gd
@@ -70,7 +70,7 @@ class HTTPState:
 
 		var poll_error: Error = http.poll()
 		if poll_error != OK:
-			printerr("poll_error %s" % error_string(poll_error))
+			push_error("poll_error %s" % error_string(poll_error))
 		status = http.get_status()
 
 		if (
@@ -139,7 +139,7 @@ class HTTPState:
 				while status == HTTPClient.STATUS_BODY and exit_result == null:
 					var poll_error: int = http.poll()
 					if poll_error != OK:
-						printerr("poll_error %s" % error_string(poll_error))
+						push_error("poll_error %s" % error_string(poll_error))
 						
 					var chunk = http.read_response_body_chunk()
 					response_code = http.get_response_code()

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_character_simulation_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_character_simulation_3d.gd
@@ -9,25 +9,43 @@ func _bind_simulation_node() -> void:
 		_simulation_node.assign_game_entity_interface(game_entity_interface)
 		
 		if not game_entity.transform_changed.is_connected(_simulation_node._on_game_entity_transform_changed):
-			assert(game_entity.transform_changed.connect(_simulation_node._on_game_entity_transform_changed) == OK)
+			if not SarUtils.assert_ok(game_entity.transform_changed.connect(_simulation_node._on_game_entity_transform_changed),
+				"Could not connect signal 'game_entity.transform_changed' to '_simulation_node._on_game_entity_transform_changed'"):
+				return
 		if not game_entity.transform_pre_update.is_connected(_simulation_node._on_game_entity_transform_pre_update):
-			assert(game_entity.transform_pre_update.connect(_simulation_node._on_game_entity_transform_pre_update) == OK)
+			if not SarUtils.assert_ok(game_entity.transform_pre_update.connect(_simulation_node._on_game_entity_transform_pre_update),
+				"Could not connect signal 'game_entity.transform_pre_update' to '_simulation_node._on_game_entity_transform_pre_update'"):
+				return
 		if not game_entity.transform_post_update.is_connected(_simulation_node._on_game_entity_transform_post_update):
-			assert(game_entity.transform_post_update.connect(_simulation_node._on_game_entity_transform_post_update) == OK)
+			if not SarUtils.assert_ok(game_entity.transform_post_update.connect(_simulation_node._on_game_entity_transform_post_update),
+				"Could not connect signal 'game_entity.transform_post_update' to '_simulation_node._on_game_entity_transform_post_update'"):
+				return
 		
 		if not model_component.model_changed.is_connected(_simulation_node._on_character_model_component_model_changed):
-			assert(model_component.model_changed.connect(_simulation_node._on_character_model_component_model_changed) == OK)
+			if not SarUtils.assert_ok(model_component.model_changed.connect(_simulation_node._on_character_model_component_model_changed),
+				"Could not connect signal 'model_component.model_changed' to '_simulation_node._on_character_model_component_model_changed'"):
+				return
 		if not model_component.model_pre_change.is_connected(_simulation_node._on_character_model_component_pre_model_changed):
-			assert(model_component.model_pre_change.connect(_simulation_node._on_character_model_component_pre_model_changed) == OK)
+			if not SarUtils.assert_ok(model_component.model_pre_change.connect(_simulation_node._on_character_model_component_pre_model_changed),
+				"Could not connect signal 'model_component.model_pre_change' to '_simulation_node._on_character_model_component_pre_model_changed'"):
+				return
 		if not vessel_movement_component.pre_movement.is_connected(_simulation_node._on_vessel_movement_component_pre_movement):
-			assert(vessel_movement_component.pre_movement.connect(_simulation_node._on_vessel_movement_component_pre_movement) == OK)
+			if not SarUtils.assert_ok(vessel_movement_component.pre_movement.connect(_simulation_node._on_vessel_movement_component_pre_movement),
+				"Could not connect signal 'vessel_movement_component.pre_movement' to '_simulation_node._on_vessel_movement_component_pre_movement'"):
+				return
 		
 		if not vessel_movement_component.post_movement.is_connected(_simulation_node._on_vessel_movement_component_post_movement):
-			assert(vessel_movement_component.post_movement.connect(_simulation_node._on_vessel_movement_component_post_movement) == OK)
+			if not SarUtils.assert_ok(vessel_movement_component.post_movement.connect(_simulation_node._on_vessel_movement_component_post_movement),
+				"Could not connect signal 'vessel_movement_component.post_movement' to '_simulation_node._on_vessel_movement_component_post_movement'"):
+				return
 		if not vessel_movement_component.movement_complete.is_connected(_simulation_node._on_vessel_movement_component_movement_complete):
-			assert(vessel_movement_component.movement_complete.connect(_simulation_node._on_vessel_movement_component_movement_complete) == OK)
+			if not SarUtils.assert_ok(vessel_movement_component.movement_complete.connect(_simulation_node._on_vessel_movement_component_movement_complete),
+				"Could not connect signal 'vessel_movement_component.movement_complete' to '_simulation_node._on_vessel_movement_component_movement_complete'"):
+				return
 		if not vessel_posession_component.possessed_by_soul.is_connected(_simulation_node._on_vessel_possession_component_soul_changed):
-			assert(vessel_posession_component.possessed_by_soul.connect(_simulation_node._on_vessel_possession_component_soul_changed) == OK)
+			if not SarUtils.assert_ok(vessel_posession_component.possessed_by_soul.connect(_simulation_node._on_vessel_possession_component_soul_changed),
+				"Could not connect signal 'vessel_posession_component.possessed_by_soul' to '_simulation_node._on_vessel_possession_component_soul_changed'"):
+				return
 	
 func _unbind_simulation_node() -> void:
 	if _simulation_node:
@@ -92,7 +110,8 @@ func _update_simulation_from_scene() -> void:
 				printerr("%s does not have a simulation container node assigned." % get_name())
 				
 func _ready() -> void:
-	assert(simulation_parent_container)
+	if not SarUtils.assert_true(simulation_parent_container, "SarGameEntityComponentCharacterSimulation3D: simulation_parent_container is not available"):
+		return
 	
 	_update_simulation_from_scene()
 	

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_character_simulation_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_character_simulation_3d.gd
@@ -91,7 +91,7 @@ func _set_simulation_node(p_simulation_node: SarSimulationCharacter3D) -> void:
 			
 			_simulation_node.notify_posession_changed(vessel_posession_component.get_soul())
 	else:
-		printerr("Attempted to assign invalid simulation node. Must inherit SarSimulationCharacter3D")
+		push_error("Attempted to assign invalid simulation node. Must inherit SarSimulationCharacter3D")
 		
 func _update_simulation_from_scene() -> void:
 	if is_node_ready():
@@ -107,7 +107,7 @@ func _update_simulation_from_scene() -> void:
 				else:
 					_set_simulation_node(null)
 			else:
-				printerr("%s does not have a simulation container node assigned." % get_name())
+				push_error("%s does not have a simulation container node assigned." % get_name())
 				
 func _ready() -> void:
 	if not SarUtils.assert_true(simulation_parent_container, "SarGameEntityComponentCharacterSimulation3D: simulation_parent_container is not available"):

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_model_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_model_3d.gd
@@ -76,7 +76,7 @@ func _update_model_from_scene() -> void:
 			_model_instantiated(instance)
 			_set_model_node(instance)
 		else:
-			printerr("%s does not have a model container node assigned." % get_name())
+			push_error("%s does not have a model container node assigned." % get_name())
 	
 func _ready() -> void:
 	set_physics_process(not Engine.is_editor_hint())

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_player_multiplayer_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_player_multiplayer_3d.gd
@@ -36,7 +36,7 @@ func _setup_authority() -> void:
 	if id_string.is_valid_int():
 		game_entity.set_multiplayer_authority(id_string.to_int())
 	else:
-		printerr("Game entity %s does not conform to the naming convention %s required to determine a user authority upon spawn" % [game_entity.name, game_session_manager.get_player_entity_name_prefix()])
+		push_error("Game entity %s does not conform to the naming convention %s required to determine a user authority upon spawn" % [game_entity.name, game_session_manager.get_player_entity_name_prefix()])
 	
 	# The MultiplayerSynchronizerSpawn node always explicitly has its authority
 	# owned by the host.

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_player_multiplayer_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_player_multiplayer_3d.gd
@@ -22,10 +22,12 @@ func _sync_filter(_peer_id: int) -> bool:
 # concerning to prematurely writing too much extra bespoke multiplayer
 # code we have to maintain ourselves, so this feels like a decent stopgap.
 func _setup_authority() -> void:
-	assert(game_entity)
+	if not SarUtils.assert_true(game_entity, "SarGameEntityComponentPlayerMultiplayer3D: game_entity is not available"):
+		return
 	
 	var game_session_manager: SarGameSessionManager = get_tree().get_first_node_in_group("game_session_managers")
-	assert(game_session_manager)
+	if not SarUtils.assert_true(game_session_manager, "SarGameEntityComponentPlayerMultiplayer3D: game_session_manager is not available"):
+		return
 	
 	# Use the numbers at the end of the player name to determine the authority.
 	# This allows the player scene to go into an auto-spawn list without having to write

--- a/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_skeleton_interpolator_3d.gd
+++ b/addons/sar_game_framework/3d/entities/components/sar_game_entity_component_skeleton_interpolator_3d.gd
@@ -10,7 +10,8 @@ var _original_skeleton: Skeleton3D = null
 var _interpolated_skeleton: Skeleton3D = null
 	
 func _copy_skeleton_pose(p_src: Skeleton3D, p_target: Skeleton3D) -> void:
-	assert(p_src.get_bone_count() == p_target.get_bone_count())
+	if not SarUtils.assert_equal(p_src.get_bone_count(), p_target.get_bone_count(), "SarGameEntityComponentSkeletonInterpolation._copy_skeleton_pose: src and target have differing bone count"):
+		return
 	
 	for i: int in range(0, p_target.get_bone_count()):
 		p_target.set_bone_pose(i, p_src.get_bone_pose(i))
@@ -78,7 +79,9 @@ func _setup_interpolation_rig_for_node(p_root: Node3D, p_skeleton: Skeleton3D) -
 		secondary.skeleton = secondary.get_path_to(_interpolated_skeleton)
 	
 	_original_skeleton = p_skeleton
-	assert(_original_skeleton.skeleton_updated.connect(_reference_skeleton_updated) == OK)
+	if not SarUtils.assert_ok(_original_skeleton.skeleton_updated.connect(_reference_skeleton_updated),
+		"Could not connect signal '_original_skeleton.skeleton_updated' to '_reference_skeleton_updated'"):
+		return
 
 
 func _on_model_component_model_pre_change(p_new_model: SarModel3D) -> void:

--- a/addons/sar_game_framework/3d/entities/sar_game_entity_3d.gd
+++ b/addons/sar_game_framework/3d/entities/sar_game_entity_3d.gd
@@ -143,14 +143,17 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var valid_path: String = get_game_entity_valid_scene_path()
 	if not valid_path.is_empty():
 		if not _is_inherited_base_scene(self, valid_path):
-			assert(string_array.append("The script for this GameEntity must be attached to scene derived from %s." % valid_path) == false)
-		
+			SarUtils.assert_equal(string_array.append("The script for this GameEntity must be attached to scene derived from %s." % valid_path),
+			false)
+
 		if not FileAccess.file_exists(get_game_entity_valid_scene_path()):
-			assert(string_array.append("Entity file path %s does not exist." % get_game_entity_valid_scene_path()) == false)
-		
+			SarUtils.assert_equal(string_array.append("Entity file path %s does not exist." % get_game_entity_valid_scene_path()),
+			false)
+
 	# Interface assignment check
 	if not game_entity_interface:
-		assert(string_array.append("Game Entity interface has not been assigned") == false)
+		SarUtils.assert_equal(string_array.append("Game Entity interface has not been assigned"),
+		false)
 		
 	return string_array
 	

--- a/addons/sar_game_framework/3d/entities/sar_game_entity_character_3d.gd
+++ b/addons/sar_game_framework/3d/entities/sar_game_entity_character_3d.gd
@@ -19,7 +19,7 @@ func _update_model_from_scene() -> void:
 			if model_component:
 				model_component.model_scene = model_scene
 		else:
-			printerr("Game entity character interface is missing.")
+			push_error("Game entity character interface is missing.")
 
 func _nodes_scene_reimported(p_nodes: Array) -> void:
 	for node: Node in p_nodes:

--- a/addons/sar_game_framework/3d/entities/sar_game_entity_vessel_3d.gd
+++ b/addons/sar_game_framework/3d/entities/sar_game_entity_vessel_3d.gd
@@ -38,7 +38,7 @@ func _update_transform() -> void:
 				# Match visual position to physics simulation result
 				transform.origin = character_interface.get_movement_component().get_physics_transform().origin
 		else:
-			printerr("Game entity interface is missing.")
+			push_error("Game entity interface is missing.")
 			
 		transform_post_update.emit(transform)
 
@@ -59,7 +59,7 @@ func _update_physics() -> void:
 			movement_component.set_physics_position(global_transform.origin)
 			movement_component.previous_physics_position = global_transform.origin
 	else:
-		printerr("Game entity interface is missing.")
+		push_error("Game entity interface is missing.")
 	
 	# Alert external systems about transform changes
 	transform_changed.emit(global_transform)

--- a/addons/sar_game_framework/3d/modifiers/sar_interpolate_skeleton_modifier_3d.gd
+++ b/addons/sar_game_framework/3d/modifiers/sar_interpolate_skeleton_modifier_3d.gd
@@ -9,14 +9,20 @@ class_name SarInterpolateSkeletonModifier3D
 @export var interp_new: Skeleton3D = null
 
 func _copy_skeleton_pose(p_src: Skeleton3D, p_target: Skeleton3D) -> void:
-	assert(p_src.get_bone_count() == p_target.get_bone_count())
-	
+	if not SarUtils.assert_equal(p_src.get_bone_count(), p_target.get_bone_count(),
+		"SarInterpolateSkeletonModifier3D._copy_skeleton_pose: p_src and p_target Skeleton3D have differing bone count."):
+		return
+
 	for i: int in range(0, p_target.get_bone_count()):
 		p_target.set_bone_pose(i, p_src.get_bone_pose(i))
 
 func _interpolate_skeleton_pose(p_src_a: Skeleton3D, p_src_b: Skeleton3D, p_target: Skeleton3D, p_weight: float) -> void:
-	assert(p_src_a.get_bone_count() == p_target.get_bone_count())
-	assert(p_src_b.get_bone_count() == p_target.get_bone_count())
+	if not SarUtils.assert_equal(p_src_a.get_bone_count(), p_target.get_bone_count(),
+		"SarInterpolateSkeletonModifier3D._interpolate_skeleton_pose: p_src_a and p_target Skeleton3D have differing bone count."):
+		return
+	if not SarUtils.assert_equal(p_src_b.get_bone_count(), p_target.get_bone_count(),
+		"SarInterpolateSkeletonModifier3D._interpolate_skeleton_pose: p_src_b and p_target Skeleton3D have differing bone count."):
+		return
 	
 	for i: int in range(0, p_target.get_bone_count()):
 		p_target.set_bone_pose(i, p_src_a.get_bone_pose(i).interpolate_with(p_src_b.get_bone_pose(i), p_weight))

--- a/addons/sar_game_framework/3d/simulation/playspace/sar_playspace_settings_fetcher_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/playspace/sar_playspace_settings_fetcher_component_3d.gd
@@ -23,7 +23,9 @@ func _ready() -> void:
 	if not Engine.is_editor_hint():
 		var settings_manager: SarGameSettingsManager = get_tree().get_first_node_in_group("settings_managers")
 		if settings_manager:
-			assert(settings_manager.setting_updated.connect(_setting_updated) == OK)
+			if not SarUtils.assert_ok(settings_manager.setting_updated.connect(_setting_updated),
+				"Could not connect signal 'settings_manager.setting_updated' to '_setting_updated'"):
+				return
 
 ###
 

--- a/addons/sar_game_framework/3d/simulation/sar_character_simulation_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_character_simulation_3d.gd
@@ -24,6 +24,6 @@ func get_game_entity_interface() -> SarGameEntityInterfaceCharacter3D:
 ## Assigns the cached reference to the entity's game_entity_interface.
 func assign_game_entity_interface(p_gei: SarGameEntityInterfaceVessel3D) -> void:
 	if p_gei is not SarGameEntityInterfaceCharacter3D:
-		printerr("The game entity interface assigned to a SarSimulationCharacter3D is not valid.")
+		push_error("The game entity interface assigned to a SarSimulationCharacter3D is not valid.")
 	
 	game_entity_interface = p_gei

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_animator_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_animator_component_3d.gd
@@ -45,10 +45,12 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
-		assert(simulation)
+		if not SarUtils.assert_true(simulation, "SarSimulationComponentAnimator3D: simulation is not available"):
+			return
 		
 		_model_component = simulation.game_entity_interface.get_model_component()
-		assert(_model_component)
+		if not SarUtils.assert_true(_model_component, "SarSimulationComponentAnimator3D: _model_component is not available"):
+			return
 
 func _on_post_movement(_delta: float, p_velocity: Vector3) -> void:
 	_target_velocity = p_velocity * simulation.get_game_entity_interface().get_game_entity().transform.basis

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_auxiliary_motion_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_auxiliary_motion_component_3d.gd
@@ -48,10 +48,12 @@ static func _execute_auxiliary_integration(
 # Callback for the movement component's pre-integration phase.
 func _on_pre_movement(p_delta: float, _velocity: Vector3) -> void:
 	var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-	assert(game_entity_interface)
+	if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentAuxiliaryMotion3D._on_pre_movement: game_entity_interface is not available"):
+		return
 	
 	var movement_component = game_entity_interface.get_movement_component()
-	assert(movement_component)
+	if not SarUtils.assert_true(movement_component, "SarSimulationComponentAuxiliaryMotion3D._on_pre_movement: movement_component is not available"):
+		return
 	
 	var character_body_3d: CharacterBody3D = movement_component.get_physics_body()
 	

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_jump_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_jump_component_3d.gd
@@ -11,8 +11,9 @@ func _physics_process(_delta: float) -> void:
 	if not Engine.is_editor_hint():
 		# Calculate movement basis 
 		var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-		assert(game_entity_interface)
-		
+		if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentJump3D: game_entity_interface is not available"):
+			return
+
 		if _movement_component.is_grounded():
 			if should_jump:
 				_movement_component.set_velocity(_movement_component.get_velocity() + (_movement_component.get_up_direction() * jump_velocity))
@@ -20,10 +21,12 @@ func _physics_process(_delta: float) -> void:
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-		assert(game_entity_interface)
+		if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentJump3D: game_entity_interface is not available"):
+			return
 		
 		_movement_component = game_entity_interface.get_movement_component()
-		assert(_movement_component)
+		if not SarUtils.assert_true(_movement_component, "SarSimulationComponentJump3D: _movement_component is not available"):
+			return
 		
 ###
 

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_motor_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_motor_component_3d.gd
@@ -14,10 +14,12 @@ var _current_velocity: Vector3 = Vector3()
 	
 func _get_forward_direction() -> Basis:
 	var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-	assert(game_entity_interface)
-	
+	if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentMotor3D._get_forward_direction: game_entity_interface is not available"):
+		return Basis.IDENTITY
+
 	var game_entity: SarGameEntity3D = game_entity_interface.get_game_entity()
-	assert(game_entity)
+	if not SarUtils.assert_true(game_entity, "SarSimulationComponentMotor3D._get_forward_direction: game_entity is not available"):
+		return Basis.IDENTITY
 	
 	return game_entity.global_transform.basis
 
@@ -55,8 +57,9 @@ func _process_movement(p_delta: float, p_movement_vector: Vector2) -> void:
 	var desired_direction: Vector3 = (_get_forward_direction() * movement_dir).normalized()
 	
 	var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-	assert(game_entity_interface)
-	
+	if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentMotor3D._process_movement: game_entity_interface is not available"):
+		return
+
 	_current_velocity = _movement_component.get_velocity()
 	
 	if _movement_component.is_grounded():
@@ -74,10 +77,12 @@ func _physics_process(p_delta: float) -> void:
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		var game_entity_interface: SarGameEntityInterface3D = simulation.get_game_entity_interface()
-		assert(game_entity_interface)
+		if not SarUtils.assert_true(game_entity_interface, "SarSimulationComponentMotor3D: game_entity_interface is not available"):
+			return
 		
 		_movement_component = game_entity_interface.get_movement_component()
-		assert(_movement_component)
+		if not SarUtils.assert_true(_movement_component, "SarSimulationComponentMotor3D: _movement_component is not available"):
+			return
 		
 		_movement_component.character_body_3d.apply_floor_snap()
 		

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_fps_tps_xr_hybrid_playspace_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_fps_tps_xr_hybrid_playspace_component_3d.gd
@@ -99,7 +99,8 @@ func _physics_process(p_delta: float) -> void:
 
 func _process(_delta: float) -> void:
 	if not Engine.is_editor_hint():
-		assert(camera_base.top_level)
+		if not SarUtils.assert_true(camera_base.top_level, "SarPlayerSimulationFPSTPSXRHybridPlayspaceComponent3D: camera_base.top_level is not available"):
+			return
 		
 		if is_xr_enabled():
 			# If we're in XR mode, disable the interpolation on the camera base.

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_xr_origin_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_xr_origin_3d.gd
@@ -219,8 +219,12 @@ func _ready() -> void:
 				_tracker_added(tracker_name, tracker.type)
 
 			# Tracker signals
-			assert(XRServer.connect("tracker_added", _tracker_added) == OK)
-			assert(XRServer.connect("tracker_removed", _tracker_removed) == OK)
+			if not SarUtils.assert_ok(XRServer.connect("tracker_added", _tracker_added),
+				"Could not connect signal 'tracker_added' to '_tracker_added'"):
+				return
+			if not SarUtils.assert_ok(XRServer.connect("tracker_removed", _tracker_removed),
+				"Could not connect signal 'tracker_removed' to '_tracker_removed'"):
+				return
 ###
 
 ## Emitted when world_scale_centered changed.

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_xr_origin_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_xr_origin_3d.gd
@@ -40,7 +40,7 @@ func _add_hand_tracker(p_tracker_name: String, p_pose: String, p_packed_scenes: 
 		
 		return new_hand_controller
 	else:
-		printerr("_add_hand_tracker did not contain a valid XRController3D!")
+		push_error("_add_hand_tracker did not contain a valid XRController3D!")
 		return null
 
 # Callback to add a Vive tracker to the tracking space.
@@ -62,7 +62,7 @@ func _add_vive_tracker(p_tracker_name: String) -> XRController3D:
 		
 		return new_hand_controller
 	else:
-		printerr("_add_hand_tracker did not contain a valid XRController3D!")
+		push_error("_add_hand_tracker did not contain a valid XRController3D!")
 		return null
 
 # Callback to the tracker_added signal in XRServer.
@@ -100,11 +100,11 @@ func _tracker_added(p_tracker_name: String, p_type: int) -> void:
 			elif p_tracker_name == "/user/hand_tracker/right":
 				_right_hand_tracker = _add_hand_tracker("/user/hand_tracker/right", "default", right_hand_skeleton_child_scenes)
 			else:
-				printerr("Hand tracking for not supported yet for " + str(p_tracker_name))
+				push_error("Hand tracking for not supported yet for " + str(p_tracker_name))
 		elif p_type == XRServer.TRACKER_HEAD:
 			pass
 		else:
-			printerr("Unknown tracker type %s added." % str(p_type))
+			push_error("Unknown tracker type %s added." % str(p_type))
 
 # Callback to the tracker_removed signal in XRServer.
 func _tracker_removed(p_tracker_name: String, p_type: int) -> void:
@@ -163,7 +163,7 @@ func _tracker_removed(p_tracker_name: String, p_type: int) -> void:
 		elif p_type == XRServer.TRACKER_HEAD:
 			pass
 		else:
-			printerr("Unknown tracker type %s removed." % str(p_type))
+			push_error("Unknown tracker type %s removed." % str(p_type))
 
 # TODO: Look more into this
 # I would like to find a less awful way of doing this, but it seems

--- a/addons/sar_game_framework/3d/simulation/sar_vessel_simulation_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_vessel_simulation_3d.gd
@@ -90,7 +90,8 @@ func notify_posession_changed(p_soul: SarSoul) -> void:
 
 ## Returns true if the vessel is currently possessed by a soul.
 func is_possessed() -> bool:
-	assert(game_entity_interface)
+	if not SarUtils.assert_true(game_entity_interface, "SarSimulationVessel3D: game_entity_interface is not available"):
+		return false
 	if game_entity_interface.get_possession_component().get_soul():
 		return true
 		

--- a/addons/sar_game_framework/3d/xr/xr_component_action.gd
+++ b/addons/sar_game_framework/3d/xr/xr_component_action.gd
@@ -28,5 +28,9 @@ func _button_released(p_button: String):
 func _ready() -> void:
 	var controller: XRController3D = get_parent()
 	if controller:
-		assert(controller.button_pressed.connect(_button_pressed) == OK)
-		assert(controller.button_released.connect(_button_released) == OK)
+		if not SarUtils.assert_ok(controller.button_pressed.connect(_button_pressed),
+			"Could not connect signal 'controller.button_pressed' to '_button_pressed'"):
+			return
+		if not SarUtils.assert_ok(controller.button_released.connect(_button_released),
+			"Could not connect signal 'controller.button_released' to '_button_released'"):
+			return

--- a/addons/sar_game_framework/generic/entities/component/sar_game_entity_component_player_start_logic.gd
+++ b/addons/sar_game_framework/generic/entities/component/sar_game_entity_component_player_start_logic.gd
@@ -7,5 +7,6 @@ class_name SarGameEntityComponentPlayerStartLogic
 
 func _enter_tree() -> void:
 	if not Engine.is_editor_hint():
-		assert(game_entity)
+		if not SarUtils.assert_true(game_entity, "SarGameEntityComponentPlayerStartLogic: game_entity is not available"):
+			return
 		game_entity.add_to_group("player_start")

--- a/addons/sar_game_framework/generic/entities/component/sar_game_entity_component_snapshot.gd
+++ b/addons/sar_game_framework/generic/entities/component/sar_game_entity_component_snapshot.gd
@@ -69,7 +69,8 @@ func decode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 			var buf: PackedByteArray = PackedByteArray()
 			var buf_size: int = get_size()
 			var result: int = buf.resize(buf_size)
-			assert(result == OK)
+			if not SarUtils.assert_ok(result, "SarGameEntityComponentSnapshot.sync_net_state.get: Failed to resize buffer"):
+				return PackedByteArray()
 			
 			stream.data_array = buf
 			stream.seek(0)

--- a/addons/sar_game_framework/generic/entities/sar_game_entity.gd
+++ b/addons/sar_game_framework/generic/entities/sar_game_entity.gd
@@ -98,13 +98,16 @@ func _get_configuration_warnings() -> PackedStringArray:
 	
 	var valid_path: String = get_game_entity_valid_scene_path()
 	if not _is_inherited_base_scene(self, valid_path):
-		assert(string_array.append("The script for this GameEntity must be attached to scene derived from %s." % valid_path) == false)
+		SarUtils.assert_equal(string_array.append("The script for this GameEntity must be attached to scene derived from %s." % valid_path),
+		false)
 		
 	if not game_entity_interface:
-		assert(string_array.append("Game Entity interface has not been assigned") == false)
+		SarUtils.assert_equal(string_array.append("Game Entity interface has not been assigned"),
+		false)
 		
 	if not FileAccess.file_exists(get_game_entity_valid_scene_path()):
-		assert(string_array.append("Entity file path %s does not exist." % get_game_entity_valid_scene_path()) == false)
+		SarUtils.assert_equal(string_array.append("Entity file path %s does not exist." % get_game_entity_valid_scene_path()),
+		false)
 		
 	return string_array
 	

--- a/addons/sar_game_framework/generic/extensions/sar_multiplayer_api_extension.gd
+++ b/addons/sar_game_framework/generic/extensions/sar_multiplayer_api_extension.gd
@@ -15,15 +15,26 @@ func _init() -> void:
 	var pc: Signal = peer_connected
 	var pd: Signal = peer_disconnected
 	var sd: Signal = server_disconnected
-	assert(base_multiplayer.connected_to_server.connect(func() -> void: cts.emit()) == OK)
-	assert(base_multiplayer.connection_failed.connect(func() -> void: cf.emit()) == OK)
-	assert(base_multiplayer.peer_connected.connect(func(id: int) -> void: pc.emit(id)) == OK)
-	assert(base_multiplayer.peer_disconnected.connect(func(id: int) -> void: pd.emit(id)) == OK)
-	assert(base_multiplayer.server_disconnected.connect(func() -> void: sd.emit()) == OK)
+	if not SarUtils.assert_ok(base_multiplayer.connected_to_server.connect(func() -> void: cts.emit()),
+		"Could not connect signal 'base_multiplayer.connected_to_server' to 'func() -> void: cts.emit()'"):
+		return
+	if not SarUtils.assert_ok(base_multiplayer.connection_failed.connect(func() -> void: cf.emit()),
+		"Could not connect signal 'base_multiplayer.connection_failed' to 'func() -> void: cf.emit()'"):
+		return
+	if not SarUtils.assert_ok(base_multiplayer.peer_connected.connect(func(id: int) -> void: pc.emit(id)),
+		"Could not connect signal 'base_multiplayer.peer_connected' to 'func(id: int) -> void: pc.emit(id)'"):
+		return
+	if not SarUtils.assert_ok(base_multiplayer.peer_disconnected.connect(func(id: int) -> void: pd.emit(id)),
+		"Could not connect signal 'base_multiplayer.peer_disconnected' to 'func(id: int) -> void: pd.emit(id)'"):
+		return
+	if not SarUtils.assert_ok(base_multiplayer.server_disconnected.connect(func() -> void: sd.emit()),
+		"Could not connect signal 'base_multiplayer.server_disconnected' to 'func() -> void: sd.emit()'"):
+		return
 
 func _rpc(peer: int, object: Object, method: StringName, args: Array) -> Error: # Error
 	#print(get_unique_id_string() + ": Got RPC for %d: %s::%s(%s)" % [peer, object, method, args])
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._rpc: base_multiplayer is not available"):
+		return FAILED
 	return base_multiplayer.rpc(peer, object, method, args)
 
 func _object_configuration_add(object: Object, config: Variant) -> Error:
@@ -31,7 +42,8 @@ func _object_configuration_add(object: Object, config: Variant) -> Error:
 	#	print(get_unique_id_string() + ": Adding synchronization configuration for %s. Synchronizer: %s" % [object, config])
 	#elif config is MultiplayerSpawner:
 	#	print(get_unique_id_string() + ": Adding node %s to the spawn list. Spawner: %s" % [object, config])
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._object_configuration_add: base_multiplayer is not available"):
+		return FAILED
 	return base_multiplayer.object_configuration_add(object, config)
 
 func _object_configuration_remove(object: Object, config: Variant) -> Error:
@@ -39,29 +51,36 @@ func _object_configuration_remove(object: Object, config: Variant) -> Error:
 	#	print(get_unique_id_string() + ": Removing synchronization configuration for %s. Synchronizer: %s" % [object, config])
 	#elif config is MultiplayerSpawner:
 	#	print(get_unique_id_string() + ": Removing node %s from the spawn list. Spawner: %s" % [object, config])
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._object_configuration_remove: base_multiplayer is not available"):
+		return FAILED
 	return base_multiplayer.object_configuration_remove(object, config)
 
 func _set_multiplayer_peer(p_peer: MultiplayerPeer) -> void:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._set_multiplayer_peer: base_multiplayer is not available"):
+		return
 	base_multiplayer.multiplayer_peer = p_peer
 
 func _get_multiplayer_peer() -> MultiplayerPeer:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._get_multiplayer_peer: base_multiplayer is not available"):
+		return null
 	return base_multiplayer.multiplayer_peer
 
 func _get_unique_id() -> int:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._get_unique_id: base_multiplayer is not available"):
+		return 0
 	return base_multiplayer.get_unique_id()
 
 func _get_peer_ids() -> PackedInt32Array:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._get_peer_ids: base_multiplayer is not available"):
+		return PackedInt32Array()
 	return base_multiplayer.get_peers()
 	
 func _get_remote_sender_id() -> int:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._get_remote_sender_id: base_multiplayer is not available"):
+		return 0
 	return base_multiplayer.get_remote_sender_id()
 	
 func _poll() -> Error:
-	assert(base_multiplayer)
+	if not SarUtils.assert_true(base_multiplayer, "SarMultiplayerAPIExtension._poll: base_multiplayer is not available"):
+		return FAILED
 	return base_multiplayer.poll()

--- a/addons/sar_game_framework/generic/helpers/script_utilities.gd
+++ b/addons/sar_game_framework/generic/helpers/script_utilities.gd
@@ -1,6 +1,6 @@
 @tool
 extends RefCounted
-class_name SarScriptUtilities
+class_name SarUtils
 
 ## This class contains helper functions designed for dealing with scripts.
 
@@ -19,3 +19,78 @@ static func does_script_inherit(
 			script = script.get_base_script()
 			
 	return false
+
+static func is_falsy(value: Variant) -> bool:
+	return not value
+
+static func is_truthy(value: Variant) -> bool:
+	return not not value
+
+## Assert Utilities
+## Improved 'assert()' functions to ensure passed statements with side-effects 
+## are evaluated in exported releases too.
+##
+## WARNING: These functions won't pause execution in release builds.
+## If required you MUST check return value and early exit,
+## like "if not SarUtils.assert_ok(___, error_msg): return"';
+
+## Returns true if first two parameters are equal, else prints error message
+## and return false.
+static func assert_equal(
+	p_value: Variant,
+	p_expected: Variant,
+	p_error_msg: String = "'p_value' is not equal to 'p_expected'"
+) -> bool:
+	var result: bool = p_value == p_expected
+	if not result:
+		push_error("Assert Error: " + p_error_msg)
+		# Editor debugger only
+		print_stack()
+		assert(result)
+	return result
+
+## Returns true if first parameter evaluates to 'true', else prints error message
+## and return false.
+static func assert_true(
+	p_value: Variant,
+	p_error_msg: String = "p_value is 'false'"
+) -> bool:
+	var result: bool = is_truthy(p_value)
+	if not result:
+		push_error("Assert Error: " + p_error_msg)
+		# Editor debugger only
+		print_stack()
+		assert(result)
+	return result
+
+## Returns true if first parameter is not 'null', else prints error message
+## and return false.
+static func assert_exists(
+	p_value: Variant,
+	p_error_msg: String = "p_value is 'null'"
+) -> bool:
+	var result: bool = true
+	if p_value == null:
+		result = false
+		push_error("Assert Error: " + p_error_msg)
+		# Editor debugger only
+		print_stack()
+		assert(result)
+	return result
+
+## Returns true if first parameter is 'OK', else prints error message
+## and return false.
+static func assert_ok(
+	p_value: Error,
+	p_error_msg: String = ""
+) -> bool:
+	var result: bool = p_value == OK
+	if not result:
+		var error_msg = p_error_msg
+		if error_msg == "":
+			error_msg = "p_value is " + error_string(p_value)
+		push_error("Assert Error: " + error_msg)
+		# Editor debugger only
+		print_stack()
+		assert(result)
+	return result

--- a/addons/sar_game_framework/generic/managers/game_session_manager/sar_game_session_authentication.gd
+++ b/addons/sar_game_framework/generic/managers/game_session_manager/sar_game_session_authentication.gd
@@ -57,7 +57,9 @@ func auth_callback(p_sender_id: int, p_buffer: PackedByteArray) -> void:
 				if auth_error_code == OK:
 					var result: Error = scene_multiplayer.complete_auth(p_sender_id)
 					if result == OK:
-						assert(authentication_peers_state_table.erase(p_sender_id) == true)
+						if not SarUtils.assert_true(authentication_peers_state_table.erase(p_sender_id),
+							"SarGameSessionAuthentication.auth_callback: Could not erase p_sender_id %s. Sender id not found in authentication_peers_state_table." % p_sender_id):
+							return
 					else:
 						printerr("multiplayer complete_auth returned an error code %s" % result)
 				else:
@@ -88,4 +90,6 @@ func peer_authenticating(p_peer_id: int) -> void:
 func peer_authentication_failed(p_peer_id: int) -> void:
 	print("peer_authentication_failed: %s" % p_peer_id)
 	if multiplayer.get_unique_id() == game_session_manager.get_host_peer_id():
-		assert(authentication_peers_state_table.erase(p_peer_id) == true)
+		if not SarUtils.assert_true(authentication_peers_state_table.erase(p_peer_id),
+			"SarGameSessionAuthentication.peer_authentication_failed: Could not erase p_peer_id %s. Peer id not found in authentication_peers_state_table." % p_peer_id):
+			return

--- a/addons/sar_game_framework/generic/managers/game_session_manager/sar_game_session_authentication.gd
+++ b/addons/sar_game_framework/generic/managers/game_session_manager/sar_game_session_authentication.gd
@@ -39,13 +39,13 @@ func auth_callback(p_sender_id: int, p_buffer: PackedByteArray) -> void:
 					PackedByteArray([AuthenticationStage.GAME_SCENE_LOADED
 					]))
 				if auth_error_code != OK:
-					printerr("send_auth returned with error code %s" % auth_error_code)
+					push_error("send_auth returned with error code %s" % auth_error_code)
 			AuthenticationStage.COMPLETE:
 				var result: Error = scene_multiplayer.complete_auth(p_sender_id)
 				if result == OK:
 					pass
 				else:
-					printerr("multiplayer complete_auth returned an error code %s" % result)
+					push_error("multiplayer complete_auth returned an error code %s" % result)
 	else:
 		# Messages from the peers.
 		match id:
@@ -61,9 +61,9 @@ func auth_callback(p_sender_id: int, p_buffer: PackedByteArray) -> void:
 							"SarGameSessionAuthentication.auth_callback: Could not erase p_sender_id %s. Sender id not found in authentication_peers_state_table." % p_sender_id):
 							return
 					else:
-						printerr("multiplayer complete_auth returned an error code %s" % result)
+						push_error("multiplayer complete_auth returned an error code %s" % result)
 				else:
-					printerr("send_auth returned with error code %s" % auth_error_code)
+					push_error("send_auth returned with error code %s" % auth_error_code)
 					
 func create_authentication_buffer() -> PackedByteArray:
 	var buffer: PackedByteArray = PackedByteArray()
@@ -85,7 +85,7 @@ func peer_authenticating(p_peer_id: int) -> void:
 		
 		var result: Error = scene_multiplayer.send_auth(p_peer_id, create_authentication_buffer())
 		if result != OK:
-			printerr("multiplayer send_auth returned an error code %s" % result)
+			push_error("multiplayer send_auth returned an error code %s" % result)
 			
 func peer_authentication_failed(p_peer_id: int) -> void:
 	print("peer_authentication_failed: %s" % p_peer_id)

--- a/addons/sar_game_framework/generic/managers/sar_game_service_manager.gd
+++ b/addons/sar_game_framework/generic/managers/sar_game_service_manager.gd
@@ -8,7 +8,7 @@ var _services: Dictionary[String, SarGameService] = {}
 
 func add_service(p_service_name: StringName, p_service_class: Script) -> void:
 	if _services.has(p_service_name):
-		printerr("Duplicate service named %s" % p_service_name)
+		push_error("Duplicate service named %s" % p_service_name)
 		return
 		
 	var base_service_script: Script = p_service_class
@@ -25,7 +25,7 @@ func add_service(p_service_name: StringName, p_service_class: Script) -> void:
 		_services[p_service_name] = service
 		
 	else:
-		printerr("Attempted to add a class which does not inherit SarService.")
+		push_error("Attempted to add a class which does not inherit SarService.")
 		
 func remove_service(p_service_name: String) -> void:
 	if _services.has(p_service_name):
@@ -34,7 +34,7 @@ func remove_service(p_service_name: String) -> void:
 			remove_child(service)
 		_services.erase(p_service_name) 
 	else:
-		printerr("There is no active service named %s." % p_service_name)
+		push_error("There is no active service named %s." % p_service_name)
 		
 func get_service(p_service_name: String) -> SarGameService:
 	if _services.has(p_service_name):

--- a/addons/sar_game_framework/generic/managers/sar_game_session_manager.gd
+++ b/addons/sar_game_framework/generic/managers/sar_game_session_manager.gd
@@ -64,7 +64,8 @@ func _spawn_player_soul(p_id: int) -> SarSoul:
 	var spawn_parent: Node = _get_player_spawn_parent()
 	
 	var player_soul_instance: SarSoul = _get_player_soul_scene().instantiate()
-	assert(player_soul_instance)
+	if not SarUtils.assert_true(player_soul_instance, "SarGameSessionManager._spawn_player_soul: Could not instantiate player soul scene"):
+		return null
 	player_soul_instance.name = get_player_soul_name_prefix() + str(p_id)
 	player_soul_instance.set_multiplayer_authority(p_id)
 	spawn_parent.add_child(player_soul_instance)
@@ -79,8 +80,9 @@ func _spawn_player_vessel(p_id: int) -> void:
 	var spawn_parent: Node = _get_player_spawn_parent()
 	
 	var player_node_instance: Node = _get_player_vessel_scene().instantiate()
-	assert(player_node_instance)
-	
+	if not SarUtils.assert_true(player_node_instance, "SarGameSessionManager._spawn_player_vessel: Could not instantiate player vessel scene"):
+		return
+
 	if player_node_instance is SarGameEntityVessel3D:
 		(player_node_instance as SarGameEntityVessel3D).global_transform = find_valid_spawn_transform_for_peer_entity_3d(p_id)
 	
@@ -117,13 +119,15 @@ func _setup_project_settings() -> void:
 		if not player_vessel_scene_path.is_empty():
 			_player_vessel_scene = load(player_vessel_scene_path)
 		
-		assert(_player_vessel_scene)
-		
+		if not SarUtils.assert_true(_player_vessel_scene, "SarGameSessionManager._setup_project_settings: Could not load player vessel scene"):
+			return
+	
 		var player_soul_scene_path: String = ProjectSettings.get_setting(_PLAYER_SOUL_SCENE_PROJECT_SETTING_PATH, "")
 		if not player_soul_scene_path.is_empty():
 			_player_soul_scene = load(player_soul_scene_path)
-		
-		assert(_player_soul_scene)
+
+		if not SarUtils.assert_true(_player_soul_scene, "SarGameSessionManager._setup_project_settings: Could not load player soul scene"):
+			return
 	else:
 		# Vessel
 		_create_scene_property(_PLAYER_VESSEL_SCENE_PROJECT_SETTING_PATH)
@@ -178,8 +182,12 @@ func _setup_multiplayer() -> void:
 		_authentication_node.set_name("Authentication")
 		
 		scene_multiplayer.set_auth_callback(_authentication_node.auth_callback)
-		assert(scene_multiplayer.peer_authenticating.connect(_authentication_node.peer_authenticating) == OK)
-		assert(scene_multiplayer.peer_authentication_failed.connect(_authentication_node.peer_authentication_failed) == OK)
+		if not SarUtils.assert_ok(scene_multiplayer.peer_authenticating.connect(_authentication_node.peer_authenticating),
+			"Could not connect signal 'scene_multiplayer.peer_authenticating' to '_authentication_node.peer_authenticating'"):
+			return
+		if not SarUtils.assert_ok(scene_multiplayer.peer_authentication_failed.connect(_authentication_node.peer_authentication_failed),
+			"Could not connect signal 'scene_multiplayer.peer_authentication_failed' to '_authentication_node.peer_authentication_failed'"):
+			return
 		
 		add_child(_authentication_node)
 		
@@ -193,13 +201,23 @@ func _setup_multiplayer() -> void:
 	_update_player_spawn_path()
 
 	# Peer connections
-	assert(multiplayer.connected_to_server.connect(_on_connected_to_server) == OK)
-	assert(multiplayer.connection_failed.connect(_on_connection_failed) == OK)
+	if not SarUtils.assert_ok(multiplayer.connected_to_server.connect(_on_connected_to_server),
+		"Could not connect signal 'multiplayer.connected_to_server' to '_on_connected_to_server'"):
+		return
+	if not SarUtils.assert_ok(multiplayer.connection_failed.connect(_on_connection_failed),
+		"Could not connect signal 'multiplayer.connection_failed' to '_on_connection_failed'"):
+		return
 
-	assert(multiplayer.peer_connected.connect(_on_peer_connect) == OK)
-	assert(multiplayer.peer_disconnected.connect(_on_peer_disconnect) == OK)
+	if not SarUtils.assert_ok(multiplayer.peer_connected.connect(_on_peer_connect),
+		"Could not connect signal 'multiplayer.peer_connected' to '_on_peer_connect'"):
+		return
+	if not SarUtils.assert_ok(multiplayer.peer_disconnected.connect(_on_peer_disconnect),
+		"Could not connect signal 'multiplayer.peer_disconnected' to '_on_peer_disconnect'"):
+		return
 
-	assert(multiplayer.server_disconnected.connect(_on_server_disconnected) == OK)
+	if not SarUtils.assert_ok(multiplayer.server_disconnected.connect(_on_server_disconnected),
+		"Could not connect signal 'multiplayer.server_disconnected' to '_on_server_disconnected'"):
+		return
 
 func _enter_tree() -> void:
 	if not Engine.is_editor_hint():

--- a/addons/sar_game_framework/generic/simulation/sar_player_simulation_character_mouse_mode_component.gd
+++ b/addons/sar_game_framework/generic/simulation/sar_player_simulation_character_mouse_mode_component.gd
@@ -49,7 +49,8 @@ func _on_shutdown() -> void:
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
-		assert(simulation)
+		if not SarUtils.assert_true(simulation, "SarSimulationComponentMouseMode: simulation is not available"):
+			return
 		_current_soul = simulation.get_game_entity_interface().get_possession_component().get_soul()
 		if not Engine.is_editor_hint():
 			_update_mouse_mode()

--- a/addons/sar_game_framework/generic/simulation/sar_player_simulation_fader.gd
+++ b/addons/sar_game_framework/generic/simulation/sar_player_simulation_fader.gd
@@ -21,7 +21,9 @@ func _request_fade_in() -> void:
 		
 		_tween = create_tween().bind_node(self).set_trans(Tween.TRANS_LINEAR)
 		
-		assert(_tween.finished.connect(_fade_in_complete) == OK)
+		if not SarUtils.assert_ok(_tween.finished.connect(_fade_in_complete),
+			"Could not connect signal '_tween.finished' to '_fade_in_complete'"):
+			return
 		
 		_tween.tween_property(
 			fade_overlay,

--- a/addons/sar_game_framework/generic/snapshots/sar_snapshot_fixed_size.gd
+++ b/addons/sar_game_framework/generic/snapshots/sar_snapshot_fixed_size.gd
@@ -13,8 +13,8 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 	
 	var pba: PackedByteArray
 	var resize_result: int = pba.resize(ceil(float(get_size()) / BITS))
-	assert(resize_result == 0)
-	
+	if not SarUtils.assert_ok(resize_result, "SarFixedSizeSnapshot: Could not resize PackedByteArray."):
+		return null
 	var parameter_stream_peer: StreamPeerBuffer = StreamPeerBuffer.new()
 	parameter_stream_peer.data_array = pba
 	parameter_stream_peer.seek(0)
@@ -23,8 +23,10 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 			parameter_stream_peer = child.encode_snapshot(parameter_stream_peer, p_bit_offset)
 		
 	var _result: Array = p_stream_peer.put_partial_data(parameter_stream_peer.data_array)
-	assert(_result[0] == OK)
-	assert(_result[1] == ceil(float(get_size()) / BITS))
+	if not SarUtils.assert_ok(_result[0], "SarFixedSizeSnapshot.encode_snapshot: Unexpected error while sending snapshot data."):
+		return null
+	if not SarUtils.assert_equal(_result[1], ceil(float(get_size()) / BITS), "SarFixedSizeSnapshot.encode_snapshot: Did not send expected number of bytes in snapshot."):
+		return null
 	
 	return p_stream_peer
 	

--- a/addons/sar_game_framework/generic/snapshots/sar_snapshot_flag.gd
+++ b/addons/sar_game_framework/generic/snapshots/sar_snapshot_flag.gd
@@ -22,13 +22,16 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 	
 	var pba: PackedByteArray
 	var resize_result: int = pba.resize(ceil(float(get_size()) / BITS))
-	assert(resize_result == OK)
+	if not SarUtils.assert_ok(resize_result, "SarFlagSnapshot.encode_snapshot: Could not resize PackedByteArray"):
+		return null
 
 	pba.encode_u8(0, value)
 	
 	var _result: Array = p_stream_peer.put_partial_data(pba)
-	assert(_result[0] == OK)
-	assert(_result[1] == ceil(float(get_size()) / BITS))
+	if not SarUtils.assert_ok(_result[0], "SarFlagSnapshot.encode_snapshot: Unexpected error while sending snapshot data."):
+		return null
+	if not SarUtils.assert_equal(_result[1], ceil(float(get_size()) / BITS), "SarFlagSnapshot.encode_snapshot: Did not send expected number of bytes in snapshot."):
+		return null
 	
 	return p_stream_peer
 	

--- a/addons/sar_game_framework/generic/snapshots/sar_snapshot_transform_3d.gd
+++ b/addons/sar_game_framework/generic/snapshots/sar_snapshot_transform_3d.gd
@@ -48,7 +48,8 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 	
 	var pba: PackedByteArray
 	var resize_result: int = pba.resize(ceil(float(get_size()) / BITS))
-	assert(resize_result == 0)
+	if not SarUtils.assert_ok(resize_result, "SarTransform3DSnapshot: Could not resize PackedByteArray."):
+		return null
 
 	var packet_idx: int = 0
 	
@@ -76,9 +77,11 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 		packet_idx += HALF_VALUE_SIZE
 	
 	var _result: Array = p_stream_peer.put_partial_data(pba)
-	assert(_result[0] == OK)
-	assert(_result[1] == ceil(float(get_size()) / BITS))
-	
+	if not SarUtils.assert_ok(_result[0], "SarTransform3DSnapshot.encode_snapshot: Unexpected error while sending snapshot data."):
+		return null
+	if not SarUtils.assert_equal(_result[1], ceil(float(get_size()) / BITS), "SarTransform3DSnapshot.encode_snapshot: Did not send expected number of bytes in snapshot."):
+		return null
+
 	return p_stream_peer
 	
 func decode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer:

--- a/addons/sar_game_framework/generic/snapshots/sar_snapshot_vector3.gd
+++ b/addons/sar_game_framework/generic/snapshots/sar_snapshot_vector3.gd
@@ -26,7 +26,8 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 	
 	var pba: PackedByteArray
 	var resize_result: int = pba.resize(ceil(float(get_size()) / BITS))
-	assert(resize_result == OK)
+	if not SarUtils.assert_ok(resize_result, "SarVector3Snapshot: Could not resize PackedByteArray."):
+		return null
 
 	var packet_idx: int = 0
 		
@@ -38,9 +39,11 @@ func encode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer
 	packet_idx += FULL_VALUE_SIZE
 		
 	var _result: Array = p_stream_peer.put_partial_data(pba)
-	assert(_result[0] == OK)
-	assert(_result[1] == ceil(float(get_size()) / BITS))
-	
+	if not SarUtils.assert_ok(_result[0], "SarVector3Snapshot.encode_snapshot: Unexpected error while sending snapshot data."):
+		return null
+	if not SarUtils.assert_equal(_result[1], ceil(float(get_size()) / BITS), "SarVector3Snapshot.encode_snapshot: Did not send expected number of bytes in snapshot."):
+		return null
+
 	return p_stream_peer
 	
 func decode_snapshot(p_stream_peer: StreamPeer, p_bit_offset: int) -> StreamPeer:

--- a/addons/sar_game_framework/generic/souls/components/sar_soul_player_camera_rotation_component.gd
+++ b/addons/sar_game_framework/generic/souls/components/sar_soul_player_camera_rotation_component.gd
@@ -15,7 +15,8 @@ func _input(p_event: InputEvent) -> void:
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel and not _is_xr_enabled():
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
-			assert(input_component)
+			if not SarUtils.assert_true(input_component, "SarSoulPlayerCameraRotationComponent: input_component is not available"):
+				return
 			
 			if p_event is InputEventMouseMotion:
 				var rotation_velocity: Vector2 = (p_event as InputEventMouseMotion).relative * MOUSE_SCALE
@@ -27,7 +28,8 @@ func _process(_delta: float) -> void:
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel:
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
-			assert(input_component)
+			if not SarUtils.assert_true(input_component, "SarSoulPlayerCameraRotationComponent: input_component is not available"):
+				return
 
 			input_component.set_input_value_for_action("camera_rotation_horizontal", Input.get_axis("rotate_camera_left", "rotate_camera_right"))
 			input_component.set_input_value_for_action("camera_rotation_vertical", Input.get_axis("rotate_camera_up", "rotate_camera_down"))

--- a/addons/sar_game_framework/generic/souls/components/sar_soul_player_commands_component.gd
+++ b/addons/sar_game_framework/generic/souls/components/sar_soul_player_commands_component.gd
@@ -13,7 +13,8 @@ func _input(p_event: InputEvent) -> void:
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel:
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
-			assert(input_component)
+			if not SarUtils.assert_true(input_component, "SarSoulPlayerCommandsComponent: _input_component is not available"):
+				return
 
 			# Workaround to persist action for one _process() frame in SarGameEntityComponentVesselInput _input_table
 			# This is needed because _input_table is processed with _physics_process() -> _update_input() in VSKPlayerSimulationInputComponent
@@ -23,12 +24,13 @@ func _input(p_event: InputEvent) -> void:
 					active_commands[command] = {"time": Time.get_ticks_usec() / 1_000_000.0, "strength": strength}
 					input_component.set_input_value_for_action(command, strength)
 
-func _physics_process(delta: float):
+func _physics_process(delta: float) -> void:
 	if not Engine.is_editor_hint() and is_multiplayer_authority():
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel:
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
-			assert(input_component)
+			if not SarUtils.assert_true(input_component, "SarSoulPlayerCommandsComponent: input_component is not available."):
+				return
 			var time = Time.get_ticks_usec() / 1_000_000.0
 			for command in active_commands:
 					var trigger_time = active_commands[command].get("time")

--- a/addons/sar_game_framework/generic/souls/components/sar_soul_player_movement_component.gd
+++ b/addons/sar_game_framework/generic/souls/components/sar_soul_player_movement_component.gd
@@ -12,7 +12,8 @@ func _process(_delta: float) -> void:
 		var vessel: SarGameEntityVessel3D = soul.get_possessed_vessel()
 		if vessel:
 			var input_component: SarGameEntityComponentVesselInput = (vessel.get_game_entity_interface() as SarGameEntityInterfaceVessel3D).get_input_component()
-			assert(input_component)
+			if not SarUtils.assert_true(input_component, "SarSoulPlayerMovementComponent: input_component is not available"):
+				return
 			
 			if InputMap.has_action("move_left") and InputMap.has_action("move_right"):
 				input_component.set_input_value_for_action("horizontal_movement", Input.get_axis("move_left", "move_right"))

--- a/addons/sar_game_framework/generic/souls/sar_soul.gd
+++ b/addons/sar_game_framework/generic/souls/sar_soul.gd
@@ -53,13 +53,13 @@ func possess(p_vessel: SarGameEntityVessel3D) -> bool:
 					possessed.emit(possessed_vessel)
 					return true
 				else:
-					printerr("Failed to possess vessel %s." % p_vessel.name)
+					push_error("Failed to possess vessel %s." % p_vessel.name)
 			else:
-				printerr("Tried to possess a %s which is already possessed by another soul." % p_vessel.name)
+				push_error("Tried to possess a %s which is already possessed by another soul." % p_vessel.name)
 		else:
-			printerr("Could not acquire valid entity interface for vessel %s." % p_vessel.name)
+			push_error("Could not acquire valid entity interface for vessel %s." % p_vessel.name)
 	else:
-		printerr("Tried to possess vessel %s which this soul does not currently have authority over." % p_vessel.name)
+		push_error("Tried to possess vessel %s which this soul does not currently have authority over." % p_vessel.name)
 		
 	return false
 	
@@ -72,9 +72,9 @@ func unpossess() -> void:
 			if interface.get_possession_component().set_soul(null):
 				possessed_vessel = null
 			else:
-				printerr("Failed to unpossess vessel %s." % possessed_vessel.name)
+				push_error("Failed to unpossess vessel %s." % possessed_vessel.name)
 		else:
-			printerr("Invalid interface when attempting to unpossess vessel %s." % possessed_vessel.name)
+			push_error("Invalid interface when attempting to unpossess vessel %s." % possessed_vessel.name)
 
 ### Returns the currently possessed vessel, or null if no vessel is possessed.
 func get_possessed_vessel() -> SarGameEntityVessel3D:

--- a/addons/vsk_editor/dashboard/vsk_editor_dashboard_avatars_control.gd
+++ b/addons/vsk_editor/dashboard/vsk_editor_dashboard_avatars_control.gd
@@ -16,15 +16,15 @@ func _on_upload_button_pressed() -> void:
 	if upload_file_dialog:
 		upload_file_dialog.popup_centered()
 	else:
-		printerr("No file dialog assigned.")
+		push_error("No file dialog assigned.")
 
 func _upload_vrm(p_path: String) -> void:
 	if _upload_request:
-		printerr("Upload is already in progress.")
+		push_error("Upload is already in progress.")
 		return
 		
 	if not FileAccess.file_exists(p_path):
-		printerr("File at path %s does not exist." % p_path)
+		push_error("File at path %s does not exist." % p_path)
 		return
 	
 	print("Attempting to upload %s" % p_path)
@@ -62,7 +62,7 @@ func _upload_vrm(p_path: String) -> void:
 				var username_and_domain: Dictionary= GodotUroHelper.get_username_and_domain_from_address(service.get_current_account_address())
 				var upload_dictionary: Dictionary = GodotUroHelper.create_content_upload_dictionary(title, "", p_path, thumbnail_image, false)
 				if upload_dictionary.is_empty():
-					printerr("Upload dictionary for VRM file %s returned empty." % p_path)
+					push_error("Upload dictionary for VRM file %s returned empty." % p_path)
 					return
 				
 				upload_button.disabled = true
@@ -79,13 +79,13 @@ func _upload_vrm(p_path: String) -> void:
 				if GodotUroHelper.requester_result_is_ok(result):
 					print("Upload was successful.")
 				else:
-					printerr("Requester code %s" % str(result.get("requester_code", GodotUroHelper.RequesterCode.UNKNOWN_STATUS_ERROR)))
+					push_error("Requester code %s" % str(result.get("requester_code", GodotUroHelper.RequesterCode.UNKNOWN_STATUS_ERROR)))
 			else:
-				printerr("Could not accquire Uro service.")
+				push_error("Could not accquire Uro service.")
 		else:
-			printerr("VRM file %s JSON is empty" % p_path)
+			push_error("VRM file %s JSON is empty" % p_path)
 	else:
-		printerr("VRM file %s returned with a parse error code: %s" % [p_path, str(error)])
+		push_error("VRM file %s returned with a parse error code: %s" % [p_path, str(error)])
 		
 func _on_upload_file_dialog_files_selected(p_paths: PackedStringArray) -> void:
 	print("Upload multiple")

--- a/addons/vsk_editor/dashboard/vsk_editor_dashboard_content_control.gd
+++ b/addons/vsk_editor/dashboard/vsk_editor_dashboard_content_control.gd
@@ -16,7 +16,7 @@ func _fetch_content(_p_service: VSKGameServiceUro, _p_username: String, _p_domai
 
 func _reload_content() -> void:
 	if not content_grid:
-		printerr("Not content grid assigned.")
+		push_error("Not content grid assigned.")
 		return
 		
 	if _fetch_request:

--- a/addons/vsk_editor/vsk_editor.gd
+++ b/addons/vsk_editor/vsk_editor.gd
@@ -253,7 +253,7 @@ func _setup_info_panel(p_root: Control) -> void:
 
 			p_root.add_child(_vsk_info_dialog, true)
 		else:
-			printerr("Could not instantiate info dialog.")
+			push_error("Could not instantiate info dialog.")
 
 
 func _setup_upload_panel(p_root: Control) -> void:

--- a/addons/vsk_editor/vsk_editor_plugin.gd
+++ b/addons/vsk_editor/vsk_editor_plugin.gd
@@ -34,7 +34,7 @@ func _enter_tree() -> void:
 	add_autoload_singleton("VSKEditorSingleton", "./vsk_editor.gd")
 	var vsk_editor: VSKEditor = get_node_or_null("/root/VSKEditorSingleton")
 	if not vsk_editor:
-		printerr("Could not setup VSKEditorSingleton.")
+		push_error("Could not setup VSKEditorSingleton.")
 		
 	_clear_uro_toolbar()
 		

--- a/addons/vsk_editor/vsk_editor_uro_toolbar_container.gd
+++ b/addons/vsk_editor/vsk_editor_uro_toolbar_container.gd
@@ -106,7 +106,7 @@ func _account_id_option_pressed(p_id: int) -> void:
 				dashboard_window.hide()
 				dashboard_window.popup_centered_ratio()
 			else:
-				printerr("Dashboard window is not assigned.")
+				push_error("Dashboard window is not assigned.")
 		# Sign Out Option
 		99:
 			var service: VSKGameServiceUro = _get_uro_service()
@@ -156,7 +156,7 @@ func teardown() -> void:
 	
 func sign_in(p_domain: String, p_username_or_email: String, p_password: String) -> Dictionary:
 	if _request:
-		printerr("A request is already active.")
+		push_error("A request is already active.")
 		return {}
 
 	var service: VSKGameServiceUro = _get_uro_service()
@@ -179,19 +179,19 @@ func cancel_sign_in() -> void:
 				if service.stop_request(_request):
 					_request = null
 				else:
-					printerr("Could not cancel request" % str(_request))
+					push_error("Could not cancel request" % str(_request))
 					
 func renew_session(p_domain: String, p_username: String) -> Dictionary:
 	if _request:
-		printerr("A request is already active.")
+		push_error("A request is already active.")
 		return {}
 		
 	if p_domain.is_empty():
-		printerr("domain is empty")
+		push_error("domain is empty")
 		return {}
 		
 	if p_username.is_empty():
-		printerr("username is empty")
+		push_error("username is empty")
 		return {}
 		
 	var service: VSKGameServiceUro = _get_uro_service()
@@ -205,7 +205,7 @@ func renew_session(p_domain: String, p_username: String) -> Dictionary:
 
 func sign_out(p_domain: String, p_username: String) -> Dictionary:
 	if _request:
-		printerr("A request is already active.")
+		push_error("A request is already active.")
 		return {}
 	
 	var service: VSKGameServiceUro = _get_uro_service()

--- a/addons/vsk_editor/vsk_editor_uro_toolbar_container.gd
+++ b/addons/vsk_editor/vsk_editor_uro_toolbar_container.gd
@@ -94,7 +94,9 @@ func _attempt_service_access() -> void:
 		
 	# No service managers? Register a callback so we can wait for one to be added.
 	if not get_tree().node_added.is_connected(_node_added):
-		assert(get_tree().node_added.connect(_node_added) == OK)
+		if not SarUtils.assert_ok(get_tree().node_added.connect(_node_added),
+			"Could not connect signal 'get_tree().node_added' to '_node_added'"):
+			return
 			
 func _account_id_option_pressed(p_id: int) -> void:
 	match p_id:
@@ -129,7 +131,9 @@ func _account_id_option_pressed(p_id: int) -> void:
 			
 func _ready() -> void:
 	if not get_tree().edited_scene_root:
-		assert(account_options_button.get_popup().id_pressed.connect(_account_id_option_pressed) == OK)
+		if not SarUtils.assert_ok(account_options_button.get_popup().id_pressed.connect(_account_id_option_pressed),
+			"Could not connect signal 'account_options_button.get_popup().id_pressed' to '_account_id_option_pressed'"):
+			return
 		
 		_update_state(State.PENDING)
 		_attempt_service_access()

--- a/addons/vsk_game_framework/scripts/entities/components/vsk_game_entity_component_avatar_loader.gd
+++ b/addons/vsk_game_framework/scripts/entities/components/vsk_game_entity_component_avatar_loader.gd
@@ -37,9 +37,11 @@ func _on_request_complete(p_asset_err: VSKGameAssetRequest.AssetError) -> void:
 		if _current_asset_request.request_complete.is_connected(_on_request_complete):
 			_current_asset_request.request_complete.disconnect(_on_request_complete)
 		_current_asset_request = null
-	
+
+	if not SarUtils.assert_true(avatar_component, "VSKGameEntityComponentAvatarLoader._on_request_complete: avatar_component is not available"):
+		return
+
 	if p_asset_err == VSKGameAssetRequest.AssetError.OK:
-		assert(avatar_component)
 		avatar_component.set_model_scene(packed_scene)
 	else:
 		var game_asset_manager: VSKGameAssetManager = get_tree().get_first_node_in_group("game_asset_managers")
@@ -78,7 +80,8 @@ func _request_avatar_asset() -> void:
 			if is_request_path_valid:
 				_current_asset_request = game_asset_manager.make_request(_requested_avatar_path, VSKGameAssetManager.AssetType.AVATAR)
 		
-		assert(avatar_component)
+		if not SarUtils.assert_true(avatar_component, "VSKGameEntityComponentAvatarLoader._request_avatar_asset: avatar_component is not available"):
+			return
 		
 		if not is_request_path_valid:
 			# If the request path is NOT valid, forcefully change the avatar the error placeholder.
@@ -89,7 +92,9 @@ func _request_avatar_asset() -> void:
 			
 			# Finally, wire up the callback signal for when the request is complete.
 			if _current_asset_request:
-				assert(_current_asset_request.request_complete.connect(_on_request_complete) == OK)
+				if not SarUtils.assert_ok(_current_asset_request.request_complete.connect(_on_request_complete),
+					"Could not connect signal '_current_asset_request.request_complete' to '_on_request_complete'"):
+					return
 			else:
 				avatar_component.set_model_scene(game_asset_manager.avatar_error_packed_scene)
 				printerr("Could not create request object for path %s" % _requested_avatar_path)
@@ -111,7 +116,8 @@ func _ready() -> void:
 	if not Engine.is_editor_hint():
 		var game_asset_manager: VSKGameAssetManager = get_tree().get_first_node_in_group("game_asset_managers")
 		if game_asset_manager:
-			assert(avatar_component)
+			if not SarUtils.assert_true(avatar_component, "VSKGameEntityComponentAvatarLoader: avatar_component is not available"):
+				return
 			avatar_component.set_model_scene(game_asset_manager.loading_avatar_packed_scene)
 		
 		if _requested_avatar_path:

--- a/addons/vsk_game_framework/scripts/entities/components/vsk_game_entity_component_avatar_loader.gd
+++ b/addons/vsk_game_framework/scripts/entities/components/vsk_game_entity_component_avatar_loader.gd
@@ -52,7 +52,7 @@ func _on_request_complete(p_asset_err: VSKGameAssetRequest.AssetError) -> void:
 				error_avatar_scene = ResourceLoader.load(error_avatar_path)
 				avatar_component.set_model_scene(error_avatar_scene)
 		else:
-			printerr("Could not access game asset manager")
+			push_error("Could not access game asset manager")
 			avatar_component.set_model_scene(null)
 			
 # Called when a new avatar request is made.
@@ -97,10 +97,10 @@ func _request_avatar_asset() -> void:
 					return
 			else:
 				avatar_component.set_model_scene(game_asset_manager.avatar_error_packed_scene)
-				printerr("Could not create request object for path %s" % _requested_avatar_path)
+				push_error("Could not create request object for path %s" % _requested_avatar_path)
 	else:
 		# This shouldn't happen, if we have the VSKGameAssetManager available as a signal.
-		printerr("Could not locate a valid VSKGameAssetManager. The custom avatar at %s cannot be loaded." % _requested_avatar_path)
+		push_error("Could not locate a valid VSKGameAssetManager. The custom avatar at %s cannot be loaded." % _requested_avatar_path)
 
 # Called when the request avatar path has changed and a new asset
 # request should be made.

--- a/addons/vsk_game_framework/scripts/managers/game_asset_manager/loaders/vsk_game_asset_loader_glb.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_asset_manager/loaders/vsk_game_asset_loader_glb.gd
@@ -16,7 +16,7 @@ static func _load_from_local_gltf_document_from_path(p_path: String, p_additiona
 	if error == OK:
 		asset_root_node = gltf_document.generate_scene(gltf_state)
 	else:
-		printerr("Failed to load GLTF scene. Returned error code %s" % str(error))
+		push_error("Failed to load GLTF scene. Returned error code %s" % str(error))
 
 	return asset_root_node
 		
@@ -39,7 +39,7 @@ static func load_glb_asset_from_path(p_game_asset_manager: VSKGameAssetManager, 
 			if error == OK:
 				packed_scene_container[0] = packed_scene
 			else:
-				printerr("Failed to pack cached GLTF scene. Returned error code %s" % str(error))
+				push_error("Failed to pack cached GLTF scene. Returned error code %s" % str(error))
 				
 		# Wait until the task completes
 		var glb_saver_task_id: int = WorkerThreadPool.add_task(glb_saver_lambda)
@@ -74,7 +74,7 @@ static func _load_and_cache_asset_from_file_path_internal(
 						
 					var error: Error = ResourceSaver.save(packed_scene, save_path, CACHE_FLAGS)
 					if error != OK:
-						printerr("Failed to save cached GLTF scene. Returned error code %s" % str(error))
+						push_error("Failed to save cached GLTF scene. Returned error code %s" % str(error))
 				
 				# Wait until the task completes
 				var packed_scene_saver_task_id: int = WorkerThreadPool.add_task(packed_scene_saver_lambda)

--- a/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_http.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_http.gd
@@ -123,7 +123,7 @@ func _send_get_request(p_skip_etag_validation: bool) -> void:
 					custom_headers.append("If-None-Match: " + stored_etag)
 
 	if _http_request.request_completed.connect(self._full_http_request_completed.bind()) != OK:
-		printerr("Could not connect signal 'request_complete'!")
+		push_error("Could not connect signal 'request_complete'!")
 
 	if _http_request.request(_request_url, custom_headers) != OK:
 		_resource = ResourceLoader.load(_game_asset_manager.get_error_path_for_asset_type(_asset_type, VSKGameAssetRequest.AssetError.UNKNOWN_FAILURE))

--- a/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_local.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_local.gd
@@ -39,7 +39,7 @@ func execute_request() -> void:
 
 		var file_exists: bool = FileAccess.file_exists(stripped_path)
 		if !file_exists:
-			printerr("Local asset not found: %s " % _request_url)
+			push_error("Local asset not found: %s " % _request_url)
 			_resource = _game_asset_manager.avatar_not_found_packed_scene
 			asset_err = AssetError.NOT_FOUND
 	else:

--- a/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_uro.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_uro.gd
@@ -18,7 +18,7 @@ func _http_request_complete(p_err: AssetError) -> void:
 		_resource = _http_game_asset_request.get_resource()
 	else:
 		_resource = null
-		printerr("Uro content HTTP request returned with error code %s" % p_err)
+		push_error("Uro content HTTP request returned with error code %s" % p_err)
 	
 	_http_game_asset_request.request_complete.disconnect(_http_request_complete)
 	_http_game_asset_request = null
@@ -27,7 +27,7 @@ func _http_request_complete(p_err: AssetError) -> void:
 
 func _uro_api_request(p_domain: String, p_id: String, p_asset_type: VSKGameAssetManager.AssetType) -> VSKGameAssetRequest:
 	if _uro_service_request:
-		printerr("Uro service requester is already active.")
+		push_error("Uro service requester is already active.")
 		return
 	
 	var game_service_manager: SarGameServiceManager = _game_asset_manager.get_tree().get_first_node_in_group("game_service_managers")

--- a/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_uro.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_asset_manager/requests/vsk_game_asset_request_uro.gd
@@ -79,7 +79,9 @@ func _uro_api_request(p_domain: String, p_id: String, p_asset_type: VSKGameAsset
 							http_url,
 							_asset_type)
 						
-						assert(http_request_obj.request_complete.connect(_http_request_complete) == OK)
+						if not SarUtils.assert_ok(http_request_obj.request_complete.connect(_http_request_complete),
+							"Could not connect signal 'http_request_obj.request_complete' to '_http_request_complete'"):
+							return
 						
 						return http_request_obj
 						

--- a/addons/vsk_game_framework/scripts/managers/game_service_manager/vsk_game_service_uro.gd
+++ b/addons/vsk_game_framework/scripts/managers/game_service_manager/vsk_game_service_uro.gd
@@ -147,17 +147,17 @@ func _process_result_and_update_registration(p_service_request: VSKGameServiceRe
 
 func _get_tokens(p_service_request: SarGameServiceRequest) -> Dictionary:
 	if not p_service_request is VSKGameServiceRequestUro:
-		printerr("Did not pass a valid VSKGameServiceRequestUro object to sign in request.")
+		push_error("Did not pass a valid VSKGameServiceRequestUro object to sign in request.")
 		return {} 
 	
 	var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
 	if domain.is_empty():
-		printerr("Did not pass a valid domain to sign in request.")
+		push_error("Did not pass a valid domain to sign in request.")
 		return {}
 		
 	var username: String = (p_service_request as VSKGameServiceRequestUro).username
 	if username.is_empty():
-		printerr("Did not pass a valid username to sign in request.")
+		push_error("Did not pass a valid username to sign in request.")
 		return {}
 	
 	var tokens: Dictionary = _godot_uro.get_tokens(username, domain)
@@ -167,7 +167,7 @@ func _get_tokens(p_service_request: SarGameServiceRequest) -> Dictionary:
 func _get_dashboard_content_async(p_service_request: SarGameServiceRequest, p_callable: Callable) -> Dictionary:
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
 			return {} 
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
@@ -195,7 +195,7 @@ func _get_dashboard_content_async(p_service_request: SarGameServiceRequest, p_ca
 func _get_individual_content_async(p_service_request: SarGameServiceRequest, p_id: String, p_callable: Callable):
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
 			return {} 
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
@@ -226,7 +226,7 @@ func _upload_content_async(
 		
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
 			return {} 
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
@@ -278,24 +278,24 @@ static func get_service_name() -> String:
 func sign_in(p_service_request: SarGameServiceRequest, p_sign_in_data: Dictionary) -> Dictionary:
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to sign in request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to sign in request.")
 			return {} 
 			
 		_current_account_address = ""
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
 		if domain.is_empty():
-			printerr("Did not pass a valid domain to a sign in request.")
+			push_error("Did not pass a valid domain to a sign in request.")
 			return {}
 		
 		var username_or_email: String = p_sign_in_data.get("username_or_email", "")
 		if username_or_email.is_empty():
-			printerr("Did not pass a valid username or email to sign in request.")
+			push_error("Did not pass a valid username or email to sign in request.")
 			return {}
 			
 		var password: String = p_sign_in_data.get("password", "")
 		if username_or_email.is_empty():
-			printerr("Did not pass a valid password to sign in request.")
+			push_error("Did not pass a valid password to sign in request.")
 			return {}
 		
 		# Add this request to the active request pool.
@@ -334,39 +334,39 @@ func sign_in(p_service_request: SarGameServiceRequest, p_sign_in_data: Dictionar
 func register(p_service_request: SarGameServiceRequest, p_register_data: Dictionary) -> Dictionary:
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to register request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to register request.")
 			return {} 
 			
 		_current_account_address = ""
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
 		if domain.is_empty():
-			printerr("Did not pass a valid domain to a register request.")
+			push_error("Did not pass a valid domain to a register request.")
 			return {}
 		
 		var email: String = p_register_data.get("email", "")
 		if email.is_empty():
-			printerr("Did not pass a valid email to register request.")
+			push_error("Did not pass a valid email to register request.")
 			return {}
 
 		var username: String = p_register_data.get("username", "")
 		if username.is_empty():
-			printerr("Did not pass a valid username to register request.")
+			push_error("Did not pass a valid username to register request.")
 			return {}
 
 		var password: String = p_register_data.get("password", "")
 		if password.is_empty():
-			printerr("Did not pass a valid password to register request.")
+			push_error("Did not pass a valid password to register request.")
 			return {}
 
 		var repeat_password: String = p_register_data.get("repeat_password", "")
 		if repeat_password.is_empty():
-			printerr("Did not pass a valid confirmation password to register request.")
+			push_error("Did not pass a valid confirmation password to register request.")
 			return {}
 
 		var _email_notifications_value = p_register_data.get("email_notifications", null)
 		if (typeof(_email_notifications_value) != TYPE_BOOL):
-			printerr("Did not pass a valid email notifications setting to register request.")
+			push_error("Did not pass a valid email notifications setting to register request.")
 			return {}
 		var email_notifications: bool = _email_notifications_value
 
@@ -404,7 +404,7 @@ func register(p_service_request: SarGameServiceRequest, p_register_data: Diction
 func renew_session(p_service_request: SarGameServiceRequest) -> Dictionary:
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to a renew request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to a renew request.")
 			return {} 
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain
@@ -432,7 +432,7 @@ func renew_session(p_service_request: SarGameServiceRequest) -> Dictionary:
 func sign_out(p_service_request: SarGameServiceRequest) -> Dictionary:
 	if _godot_uro and _godot_uro.get_api():
 		if not p_service_request is VSKGameServiceRequestUro:
-			printerr("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
+			push_error("Did not pass a valid VSKGameServiceRequestUro object to a sign out request.")
 			return {} 
 		
 		var domain: String = (p_service_request as VSKGameServiceRequestUro).domain

--- a/addons/vsk_game_framework/scripts/managers/vsk_game_asset_manager.gd
+++ b/addons/vsk_game_framework/scripts/managers/vsk_game_asset_manager.gd
@@ -114,17 +114,23 @@ func _get_or_create_request_object_for_type(p_request_url: String, p_asset_type:
 				request_obj = VSKGameAssetRequestHTTP.new(self, p_request_url, p_asset_type)
 				request_obj.execute_request.call_deferred()
 				_request_objects[p_request_url] = request_obj
-				assert(request_obj.request_complete.connect(_request_complete.bind(p_request_url)) == OK)
+				if not SarUtils.assert_ok(request_obj.request_complete.connect(_request_complete.bind(p_request_url)),
+					"Could not connect signal 'request_obj.request_complete' to '_request_complete.bind(p_request_url)'"):
+					return null
 			RequestType.LOCAL_FILE_REQUEST:
 				request_obj = VSKGameAssetRequestLocal.new(self, p_request_url, p_asset_type)
 				request_obj.execute_request.call_deferred()
 				_request_objects[p_request_url] = request_obj
-				assert(request_obj.request_complete.connect(_request_complete.bind(p_request_url)) == OK)
+				if not SarUtils.assert_ok(request_obj.request_complete.connect(_request_complete.bind(p_request_url)),
+					"Could not connect signal 'request_obj.request_complete' to '_request_complete.bind(p_request_url)'"):
+					return null
 			RequestType.URO_REQUEST:
 				request_obj = VSKGameAssetRequestUro.new(self, p_request_url, p_asset_type)
 				request_obj.execute_request.call_deferred()
 				_request_objects[p_request_url] = request_obj
-				assert(request_obj.request_complete.connect(_request_complete.bind(p_request_url)) == OK)
+				if not SarUtils.assert_ok(request_obj.request_complete.connect(_request_complete.bind(p_request_url)),
+					"Could not connect signal 'request_obj.request_complete' to '_request_complete.bind(p_request_url)'"):
+					return null
 			_:
 				printerr("Unknown file request type: %s" % str(p_request_url))
 				return null
@@ -212,15 +218,15 @@ func _ready() -> void:
 		_get_project_settings()
 		
 		avatar_forbidden_packed_scene = ResourceLoader.load(avatar_forbidden_path)
-		assert(avatar_forbidden_packed_scene)
+		SarUtils.assert_true(avatar_forbidden_packed_scene, "Could not load %s" % avatar_forbidden_path)
 		avatar_not_found_packed_scene = ResourceLoader.load(avatar_not_found_path)
-		assert(avatar_not_found_packed_scene)
+		SarUtils.assert_true(avatar_not_found_packed_scene, "Could not load %s" % avatar_not_found_path)
 		avatar_error_packed_scene = ResourceLoader.load(avatar_error_path)
-		assert(avatar_error_packed_scene)
+		SarUtils.assert_true(avatar_error_packed_scene, "Could not load %s" % avatar_error_path)
 		teapot_packed_scene = ResourceLoader.load(teapot_path)
-		assert(teapot_packed_scene)
+		SarUtils.assert_true(teapot_packed_scene, "Could not load %s" % teapot_path)
 		loading_avatar_packed_scene = ResourceLoader.load(loading_avatar_path)
-		assert(loading_avatar_packed_scene)
+		SarUtils.assert_true(loading_avatar_packed_scene, "Could not load %s" % loading_avatar_path)
 
 ###
 

--- a/addons/vsk_game_framework/scripts/managers/vsk_game_asset_manager.gd
+++ b/addons/vsk_game_framework/scripts/managers/vsk_game_asset_manager.gd
@@ -97,17 +97,17 @@ func _get_or_create_request_object_for_type(p_request_url: String, p_asset_type:
 				if request_obj is VSKGameAssetRequestHTTP:
 					return request_obj
 				else:
-					printerr("Existing asset request for %s is not a valid HTTP request.")
+					push_error("Existing asset request for %s is not a valid HTTP request.")
 			RequestType.LOCAL_FILE_REQUEST:
 				if request_obj is VSKGameAssetRequestLocal:
 					return request_obj
 				else:
-					printerr("Existing asset request for %s is not a valid local file request.")
+					push_error("Existing asset request for %s is not a valid local file request.")
 			RequestType.URO_REQUEST:
 				if request_obj is VSKGameAssetRequestUro:
 					return request_obj
 				else:
-					printerr("Existing asset request for %s is not a valid Uro request.")
+					push_error("Existing asset request for %s is not a valid Uro request.")
 	else:
 		match p_request_type:
 			RequestType.HTTP_REQUEST:
@@ -132,7 +132,7 @@ func _get_or_create_request_object_for_type(p_request_url: String, p_asset_type:
 					"Could not connect signal 'request_obj.request_complete' to '_request_complete.bind(p_request_url)'"):
 					return null
 			_:
-				printerr("Unknown file request type: %s" % str(p_request_url))
+				push_error("Unknown file request type: %s" % str(p_request_url))
 				return null
 			
 	return request_obj
@@ -200,7 +200,7 @@ func _apply_project_settings() -> void:
 			ProjectSettings.set_setting("assets/config/game_mode_allow_list", game_mode_allow_list)
 
 		if ProjectSettings.save() != OK:
-			printerr("VSKAssetManager: could not save project settings!")
+			push_error("VSKAssetManager: could not save project settings!")
 
 func _ready() -> void:
 	if Engine.is_editor_hint():
@@ -209,11 +209,11 @@ func _ready() -> void:
 	else:
 		if not DirAccess.dir_exists_absolute(get_asset_cache_path()):
 			if DirAccess.make_dir_absolute(get_asset_cache_path()) != OK:
-				printerr("Could not create asset cache directory!")
+				push_error("Could not create asset cache directory!")
 
 		if not DirAccess.dir_exists_absolute(get_unvalidated_assets_path()):
 			if DirAccess.make_dir_absolute(get_unvalidated_assets_path()) != OK:
-				printerr("Could not create unvalidated assets directory!")
+				push_error("Could not create unvalidated assets directory!")
 				
 		_get_project_settings()
 		
@@ -294,9 +294,9 @@ func is_in_allow_list(p_url: String, p_asset_type: AssetType) -> bool:
 			return true
 			
 	if p_url.is_empty():
-		printerr("Asset is not in allow list!")
+		push_error("Asset is not in allow list!")
 	else:
-		printerr("Asset %s is not in allow list!" % p_url)
+		push_error("Asset %s is not in allow list!" % p_url)
 		
 	return false
 			
@@ -334,4 +334,4 @@ func clear_cache() -> void:
 	var dir: DirAccess = DirAccess.open(get_asset_cache_path())
 	if dir != null:
 		if SarDirectoryUtilities.delete_dir_and_contents(dir, get_asset_cache_path(), false) != OK:
-			printerr("Could not delete all files in cache!")
+			push_error("Could not delete all files in cache!")

--- a/addons/vsk_game_framework/scripts/simulation/vsk_player_simulation_respawner_3d.gd
+++ b/addons/vsk_game_framework/scripts/simulation/vsk_player_simulation_respawner_3d.gd
@@ -31,7 +31,7 @@ func _respawn() -> void:
 			# Emit the signal that we have respawned.
 			respawned.emit()
 		else:
-			printerr("Attempted to respawn, but a game session manager could not be found.")
+			push_error("Attempted to respawn, but a game session manager could not be found.")
 
 func request_respawn() -> void:
 	_respawn()

--- a/addons/vsk_game_framework/scripts/souls/components/vsk_soul_player_curtain_component.gd
+++ b/addons/vsk_game_framework/scripts/souls/components/vsk_soul_player_curtain_component.gd
@@ -13,7 +13,7 @@ class_name VSKSoulPlayerCurtainComponent
 func _on_possessed(p_vessel: SarGameEntityVessel3D) -> void:
 	if not Engine.is_editor_hint() and is_multiplayer_authority():
 		if not curtain:
-			printerr("Curtain node was not assigned.")
+			push_error("Curtain node was not assigned.")
 			return
 		
 		if p_vessel:

--- a/addons/vsk_ui/keyboard/vsk_keyboard_layout.gd
+++ b/addons/vsk_ui/keyboard/vsk_keyboard_layout.gd
@@ -13,6 +13,8 @@ extends Resource
 		
 		for row: VSKKeyboardRow in rows:
 			if row:
-				assert(row.changed.connect(emit_changed) == OK)
+				if not SarUtils.assert_ok(row.changed.connect(emit_changed),
+					"Could not connect signal 'row.changed' to 'emit_changed'"):
+					return
 				
 		emit_changed()

--- a/addons/vsk_ui/keyboard/vsk_keyboard_row.gd
+++ b/addons/vsk_ui/keyboard/vsk_keyboard_row.gd
@@ -13,6 +13,8 @@ extends Resource
 		
 		for button: VSKKeyboardButton in buttons:
 			if button:
-				assert(button.changed.connect(emit_changed) == OK)
+				if not SarUtils.assert_ok(button.changed.connect(emit_changed),
+					"Could not connect signal 'button.changed' to 'emit_changed'"):
+					return
 		
 		emit_changed()

--- a/addons/vsk_ui/view_controllers/navigation_controllers/vsk_ui_navigation_controller_startup.gd
+++ b/addons/vsk_ui/view_controllers/navigation_controllers/vsk_ui_navigation_controller_startup.gd
@@ -21,7 +21,9 @@ func _add_view_controller_to_content(p_view_controller: SarUIViewController) -> 
 	#var navbar: HBoxContainer = HBoxContainer.new()
 	#var button: Button = Button.new()
 	#button.text = "Back"
-	#assert(button.pressed.connect(_back_button_pressed) == OK)
+	#if not SarUtils.assert_ok(button.pressed.connect(_back_button_pressed),
+	#	"Could not connect signal 'button.pressed' to '_back_button_pressed'"):
+	#	return
 	
 	#navbar.add_child(button)
 	if get_view_controllers().size() > 1:
@@ -42,7 +44,9 @@ func _add_view_controller_to_content(p_view_controller: SarUIViewController) -> 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		back_button.hide()
-		assert(back_button.pressed.connect(_back_button_pressed) == OK)
+		if not SarUtils.assert_ok(back_button.pressed.connect(_back_button_pressed),
+			"Could not connect signal 'back_button.pressed' to '_back_button_pressed'"):
+			return
 
 ###
 
@@ -52,7 +56,8 @@ func _ready() -> void:
 signal message_box_requested(p_title: String, p_body: String)
 
 func show_messagebox(p_title: String, p_body: String) -> void:
-	assert(message_box_requested.has_connections())
+	if not SarUtils.assert_true(message_box_requested.has_connections(), "Signal 'message_box_requested' has no connected callbacks"):
+		return
 	
 	block_input()
 	message_box_requested.emit(p_title, p_body)

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_account_action.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_account_action.gd
@@ -9,7 +9,9 @@ func _domain_selected(p_url: String) -> void:
 
 func _on_view_pick_other_domain_selected() -> void:
 	var view_controller: VSKUIViewControllerDomainSelector = _DOMAIN_SELECTOR_VIEW_CONTROLLER.instantiate()
-	assert(view_controller.domain_selected.connect(_domain_selected) == OK)
+	if not SarUtils.assert_ok(view_controller.domain_selected.connect(_domain_selected),
+		"Could not connect signal 'view_controller.domain_selected' to '_domain_selected'"):
+		return
 	get_navigation_controller().push_view_controller(view_controller, true)
 	view_controller.set_url(view.get_domain())
 
@@ -17,7 +19,8 @@ func _ready() -> void:
 	super._ready()
 	
 	if not Engine.is_editor_hint():
-		assert(view)
+		if not SarUtils.assert_true(view, "VSKUIViewControllerAccountAction: view is not available"):
+			return
 		
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray = []

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_big_menu.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_big_menu.gd
@@ -18,8 +18,9 @@ func _on_avatars_content_selected(p_url: String) -> void:
 signal message_box_requested(p_title: String, p_body: String)
 
 func show_messagebox(p_title: String, p_body: String) -> void:
-	assert(message_box_requested.has_connections())
-	
+	if not SarUtils.assert_true(message_box_requested.has_connections(), "Signal 'message_box_requested' has no connected callbacks"):
+		return
+
 	message_box_requested.emit(p_title, p_body)
 
 func show_keyboard() -> void:

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_logging_in.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_logging_in.gd
@@ -60,12 +60,17 @@ func _ready() -> void:
 
 ## Call this method to request a sign in with a game service.
 func sign_in(p_game_service: SarGameService, p_sign_in_data: Dictionary) -> void:
-	assert(_service == null)
-	assert(_request == null)
+
+	if not SarUtils.assert_equal(_service, null, "VSKUIViewControllerLoggingIn.sign_in: '_service' already exists"):
+		return
+	if not SarUtils.assert_equal(_request, null, "VSKUIViewControllerLoggingIn.sign_in: '_request' already exists"):
+		return
 	
 	_service = p_game_service
 	
-	assert(_service.session_request_complete.connect(_session_request_complete) == OK)
+	if not SarUtils.assert_ok(_service.session_request_complete.connect(_session_request_complete),
+		"Could not connect signal '_service.session_request_complete' to '_session_request_complete'"):
+		return
 	
 	_domain = p_sign_in_data.get("domain", "")
 	_username = ""

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_login.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_login.gd
@@ -38,4 +38,6 @@ func _on_view_sign_in_selected() -> void:
 	view_controller.sign_in(_get_uro_service(), sign_in_data)
 	get_navigation_controller().push_view_controller(view_controller, true)
 	
-	assert(view_controller.sign_in_complete.connect(_sign_in_complete) == OK)
+	if not SarUtils.assert_ok(view_controller.sign_in_complete.connect(_sign_in_complete),
+		"Could not connect signal 'view_controller.sign_in_complete' to '_sign_in_complete'"):
+		return

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_register.gd
@@ -44,4 +44,6 @@ func _on_view_sign_up_selected() -> void:
 	view_controller.register(_get_uro_service(), register_data)
 	get_navigation_controller().push_view_controller(view_controller, true)
 	
-	assert(view_controller.sign_up_complete.connect(_sign_up_complete) == OK)
+	if not SarUtils.assert_ok(view_controller.sign_up_complete.connect(_sign_up_complete),
+		"Could not connect signal 'view_controller.sign_up_complete' to '_sign_up_complete'"):
+		return

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_registering_account.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_registering_account.gd
@@ -63,12 +63,16 @@ func _ready() -> void:
 
 ## Call this method to request a registration with a game service.
 func register(p_game_service: SarGameService, p_register_data: Dictionary) -> void:
-	assert(_service == null)
-	assert(_request == null)
+	if not SarUtils.assert_equal(_service, null, "VSKUIViewControllerRegistering.register: '_service' already exists"):
+		return
+	if not SarUtils.assert_equal(_request, null, "VSKUIViewControllerRegistering.register: '_request' already exists"):
+		return
 	
 	_service = p_game_service
 	
-	assert(_service.session_request_complete.connect(_session_request_complete) == OK)
+	if not SarUtils.assert_ok(_service.session_request_complete.connect(_session_request_complete),
+		"Could not connect signal '_service.session_request_complete' to '_session_request_complete'"):
+		return
 	
 	_domain = p_register_data.get("domain", "")
 	_username = ""

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_session_loading.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_session_loading.gd
@@ -33,7 +33,9 @@ func _ready() -> void:
 		var asset_manager: VSKGameAssetManager = get_tree().get_first_node_in_group("game_asset_managers")
 		if asset_manager:
 			_request_object = asset_manager.make_request(content_url, VSKGameAssetManager.AssetType.MAP)
-			assert(_request_object.request_complete.connect(_request_complete) == OK)
+			if not SarUtils.assert_ok(_request_object.request_complete.connect(_request_complete),
+				"Could not connect signal '_request_object.request_complete' to '_request_complete'"):
+				return
 			
 ###
 

--- a/addons/vsk_ui/view_controllers/vsk_ui_view_controller_welcome.gd
+++ b/addons/vsk_ui/view_controllers/vsk_ui_view_controller_welcome.gd
@@ -26,13 +26,17 @@ func _on_welcome_menu_sign_in_pressed() -> void:
 	var view_controller: VSKUIViewControllerLogin = _LOGIN_VIEW_CONTROLLER.instantiate()
 	get_navigation_controller().push_view_controller(view_controller, true)
 
-	assert(view_controller.signed_in.connect(_signed_in) == OK)
+	if not SarUtils.assert_ok(view_controller.signed_in.connect(_signed_in),
+		"Could not connect signal 'view_controller.signed_in' to '_signed_in'"):
+		return
 
 func _on_welcome_menu_register_pressed() -> void:
 	var view_controller: VSKUIViewControllerRegister = _REGISTER_VIEW_CONTROLLER.instantiate()
 	get_navigation_controller().push_view_controller(view_controller, true)
 
-	assert(view_controller.signed_up.connect(_signed_up) == OK)
+	if not SarUtils.assert_ok(view_controller.signed_up.connect(_signed_up),
+		"Could not connect signal 'view_controller.signed_up' to '_signed_up'"):
+		return
 
 func _on_welcome_menu_skip_pressed() -> void:
 	get_navigation_controller().pop_view_controller(true)

--- a/addons/vsk_ui/views/vsk_ui_view_avatar_menu.gd
+++ b/addons/vsk_ui/views/vsk_ui_view_avatar_menu.gd
@@ -30,6 +30,8 @@ func _fetch_content() -> void:
 							url)
 							
 						var avatar_url: String = "uro://" + dict.get("domain", "") + "/" + avatar.get("id", "")
-						assert(button.pressed.connect(_content_selected.bind(avatar_url)) == OK)
+						if not SarUtils.assert_ok(button.pressed.connect(_content_selected.bind(avatar_url)),
+							"Could not connect signal 'button.pressed' to '_content_selected.bind(avatar_url)'"):
+							return
 	else:
 		printerr("Could not access Uro service for avatar browser.")

--- a/addons/vsk_ui/views/vsk_ui_view_avatar_menu.gd
+++ b/addons/vsk_ui/views/vsk_ui_view_avatar_menu.gd
@@ -6,7 +6,7 @@ var _request: SarGameServiceRequest = null
 
 func _fetch_content() -> void:
 	if _request:
-		printerr("Request already in progress")
+		push_error("Request already in progress")
 		return
 	
 	_clear_content()
@@ -34,4 +34,4 @@ func _fetch_content() -> void:
 							"Could not connect signal 'button.pressed' to '_content_selected.bind(avatar_url)'"):
 							return
 	else:
-		printerr("Could not access Uro service for avatar browser.")
+		push_error("Could not access Uro service for avatar browser.")

--- a/addons/vsk_ui/views/vsk_ui_view_content_browser.gd
+++ b/addons/vsk_ui/views/vsk_ui_view_content_browser.gd
@@ -23,7 +23,9 @@ func _notification(p_what: int) -> void:
 
 func _ready() -> void:
 	if content_item_container:
-		assert(content_item_container.resized.connect(_content_item_container_resized) == OK)
+		if not SarUtils.assert_ok(content_item_container.resized.connect(_content_item_container_resized),
+			"Could not connect signal 'content_item_container.resized' to '_content_item_container_resized'"):
+			return
 
 ###
 

--- a/addons/vsk_ui/views/vsk_ui_view_domain_selector.gd
+++ b/addons/vsk_ui/views/vsk_ui_view_domain_selector.gd
@@ -73,8 +73,13 @@ func _update_radio_buttons() -> void:
 					_other_homeserver_line_edit.placeholder_text = "Other Homeserver"
 					_other_homeserver_line_edit.expand_to_text_length = true
 					_other_homeserver_line_edit.virtual_keyboard_type = LineEdit.KEYBOARD_TYPE_URL
-					assert(_other_homeserver_line_edit.editing_toggled.connect(_on_other_homeserver_line_edit_editing_toggled) == OK)
-					assert(_other_homeserver_line_edit.text_changed.connect(_on_other_homeserver_line_edit_text_changed) == OK)
+
+					if not SarUtils.assert_ok(_other_homeserver_line_edit.editing_toggled.connect(_on_other_homeserver_line_edit_editing_toggled),
+						"Could not connect signal '_other_homeserver_line_edit.editing_toggled' to '_on_other_homeserver_line_edit_editing_toggled'"):
+						return
+					if not SarUtils.assert_ok(_other_homeserver_line_edit.text_changed.connect(_on_other_homeserver_line_edit_text_changed),
+						"Could not connect signal '_other_homeserver_line_edit.text_changed' to '_on_other_homeserver_line_edit_text_changed'"):
+						return
 					hbox_container.add_child(_other_homeserver_line_edit)
 					
 					_homeserver_list.add_child(hbox_container)
@@ -93,7 +98,9 @@ func _ready() -> void:
 		homeserver_info = p_homeserver_info
 		
 		if homeserver_info:
-			assert(homeserver_info.changed.connect(_homeserver_info_changed) == OK)
+			if not SarUtils.assert_ok(homeserver_info.changed.connect(_homeserver_info_changed),
+				"Could not connect signal 'homeserver_info.changed' to '_homeserver_info_changed'"):
+				return
 		
 		_update_radio_buttons()
 		

--- a/addons/vsk_ui/vsk_keyboard.gd
+++ b/addons/vsk_ui/vsk_keyboard.gd
@@ -13,7 +13,9 @@ var container: VBoxContainer = null
 		keyboard_layout = p_keyboard_layout
 		
 		if keyboard_layout:
-			assert(keyboard_layout.changed.connect(_keyboard_layout_updated) == OK)
+			if not SarUtils.assert_ok(keyboard_layout.changed.connect(_keyboard_layout_updated),
+				"Could not connect signal 'keyboard_layout.changed' to '_keyboard_layout_updated'"):
+				return
 		
 		_keyboard_layout_updated()
 

--- a/vsk_default/scenes/vsk_startup_scene.gd
+++ b/vsk_default/scenes/vsk_startup_scene.gd
@@ -27,10 +27,12 @@ func _get_uro_service() -> VSKGameServiceUro:
 func _scene_load_complete(p_packed_scene: Resource) -> void:
 	navigation_controller_2d.pop_view_controller(false)
 	
-	assert(get_tree())
-	
+	if not SarUtils.assert_exists(get_tree()):
+		return
+
 	if p_packed_scene is PackedScene:
-		assert(get_tree())
+		if not SarUtils.assert_exists(get_tree()):
+			return
 		var scene_changed = get_tree().scene_changed
 		get_tree().change_scene_to_packed(p_packed_scene)
 		await scene_changed
@@ -42,17 +44,25 @@ func _show_scene_loading_screen() -> void:
 	var view_controller: VSKUIViewControllerSessionLoading = _SESSION_LOADING_VIEW_CONTROLLER.instantiate()
 	view_controller.content_url = DEFAULT_GAME_SCENE_URL
 	
-	assert(get_tree())
-	
-	assert(view_controller.scene_loaded.connect(_scene_load_complete) == OK)
+	if not SarUtils.assert_exists(get_tree()):
+		return
+
+	if not SarUtils.assert_ok(view_controller.scene_loaded.connect(_scene_load_complete),
+		"Could not connect signal 'view_controller.scene_loaded' to '_scene_load_complete'"):
+		return
+
 	navigation_controller_2d.push_view_controller(view_controller, false)
 	
 func _show_welcome_screen() -> void:
 	var view_controller: VSKUIViewControllerWelcome = _WELCOME_VIEW_CONTROLLER.instantiate()
 	navigation_controller_2d.push_view_controller(view_controller, false)
 	
-	assert(view_controller.signed_in.connect(_sign_in_complete) == OK)
-	assert(view_controller.skipped.connect(_sign_in_complete.bind("")) == OK)
+	if not SarUtils.assert_ok(view_controller.signed_in.connect(_sign_in_complete),
+		"Could not connect signal 'view_controller.signed_in' to '_sign_in_complete'"):
+		return
+	if not SarUtils.assert_ok(view_controller.skipped.connect(_sign_in_complete.bind("")),
+		"Could not connect signal 'view_controller.skipped' to '_sign_in_complete'"):
+		return
 	
 func _show_validate_screen() -> void:
 	var view_controller: VSKUIViewControllerValidating = _VALIDATING_VIEW_CONTROLLER.instantiate()


### PR DESCRIPTION
Using `assert()` statements with side-effects leads to unexpected behaviour in exported builds since they are not evaluated. https://github.com/V-Sekai/v-sekai-game/issues/474#issuecomment-2603661420

This PR introduces `assert()` wrappers in `VSKUtils` that guarantee execution of side-effects.
Also, `printerr()` calls are replaced with `push_error()`
Custom linter was re-enabled on rx branch.