### PR TITLE
Fix EditorInterface export bug and flat mode startup warning

### DIFF
--- a/addons/animation_tree_driver/animation_tree_driver.gd
+++ b/addons/animation_tree_driver/animation_tree_driver.gd
@@ -22,6 +22,8 @@ class_name AnimationTreeDriver
 
 var _property_values: Dictionary[String, Variant] = {}
 
+var _editor_interface = null
+
 func _changed() -> void:
 	if Engine.is_editor_hint():
 		if animation_tree:
@@ -123,13 +125,17 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 	
 func _property_edited(p_property: String) -> void:
-	if EditorInterface.get_inspector().get_edited_object() is AnimationTree:
+	if _editor_interface and _editor_interface.get_inspector().get_edited_object() is AnimationTree:
 		if p_property == "advance_expression_base_node":
 			update_configuration_warnings()
 	
 func _ready() -> void:
 	if Engine.is_editor_hint():
-		EditorInterface.get_inspector().property_edited.connect(_property_edited)
+		_editor_interface = Engine.get_singleton("EditorInterface")
+		if not _editor_interface:
+			push_error("EditorInterface singleton is not available")
+			return
+		_editor_interface.get_inspector().property_edited.connect(_property_edited)
 ##
 
 ## Reference the AnimationTree this node is meant to drive and

--- a/addons/sar_game_framework/3d/entities/sar_game_entity_3d.gd
+++ b/addons/sar_game_framework/3d/entities/sar_game_entity_3d.gd
@@ -105,9 +105,13 @@ func _get_property_list() -> Array[Dictionary]:
 	var interface_path_usage: int = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE
 	if Engine.is_editor_hint():
 		var valid_path: String = get_game_entity_valid_scene_path()
-		
+
+		var editor_interface = Engine.get_singleton("EditorInterface")
+		if not editor_interface:
+			push_error("EditorInterface singleton is not available")
+			return properties
 		if not valid_path.is_empty():
-			if not (EditorInterface.get_edited_scene_root() == self and self.scene_file_path == valid_path):
+			if not (editor_interface.get_edited_scene_root() == self and self.scene_file_path == valid_path):
 				interface_path_usage = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_SCRIPT_VARIABLE
 		
 	# Add interface reference property

--- a/addons/sar_game_framework/generic/entities/sar_game_entity.gd
+++ b/addons/sar_game_framework/generic/entities/sar_game_entity.gd
@@ -67,8 +67,12 @@ func _get_property_list() -> Array[Dictionary]:
 	var interface_path_usage: int = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE
 	if Engine.is_editor_hint():
 		var valid_path: String = get_game_entity_valid_scene_path()
-		
-		if not (EditorInterface.get_edited_scene_root() == self and self.scene_file_path == valid_path):
+
+		var editor_interface = Engine.get_singleton("EditorInterface")
+		if not editor_interface:
+			push_error("EditorInterface singleton is not available")
+			return properties
+		if not (editor_interface.get_edited_scene_root() == self and self.scene_file_path == valid_path):
 			interface_path_usage = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_SCRIPT_VARIABLE
 		
 	properties.append({

--- a/addons/vsk_editor/vsk_editor.gd
+++ b/addons/vsk_editor/vsk_editor.gd
@@ -16,7 +16,7 @@ var _vsk_info_dialog: VSKEditorInfoDialog = null
 
 #const vsk_types_const = preload("res://addons/vsk_importer_exporter/vsk_types.gd")
 
-var _editor_interface: EditorInterface = null
+var _editor_interface = null # EditorInterface
 
 var _uro_toolbar: VSKEditorUroToolbarContainer = null
 
@@ -62,7 +62,7 @@ static func _update_uro_pipeline(
 func user_content_new_uro_id(p_node: Node, p_id: String) -> void:
 	var id: String = ""
 	_update_uro_pipeline(
-		EditorInterface.get_edited_scene_root(), p_node, p_id, true
+		_editor_interface.get_edited_scene_root(), p_node, p_id, true
 	)
 
 	print("user_content_new_uro_id: %s" % id)
@@ -271,7 +271,7 @@ func _setup_upload_panel(p_root: Control) -> void:
 
 
 func setup_editor(
-	p_root: Control, p_uro_toolbar: VSKEditorUroToolbarContainer, p_editor_interface: EditorInterface
+	p_root: Control, p_uro_toolbar: VSKEditorUroToolbarContainer
 ) -> void:
 	print("VSKEditor::setup_editor")
 
@@ -284,7 +284,6 @@ func setup_editor(
 	_setup_progress_panel(p_root)
 	_setup_info_panel(p_root)
 
-	_editor_interface = p_editor_interface
 
 
 ##
@@ -449,7 +448,10 @@ func _packed_scene_upload_failed_callback(p_error_message: String) -> void:
 ##
 
 func _enter_tree():
-	pass
+	_editor_interface = Engine.get_singleton("EditorInterface")
+	if not _editor_interface:
+		push_error("EditorInterface singleton is not available")
+		return
 
 
 func _exit_tree():

--- a/addons/vsk_editor/vsk_editor_plugin.gd
+++ b/addons/vsk_editor/vsk_editor_plugin.gd
@@ -11,6 +11,8 @@ const URO_LOGO = preload("./icon.svg")
 
 var _uro_toolbar: VSKEditorUroToolbarContainer = null
 
+var _editor_interface = null # EditorInterface
+
 func _init():
 	print("Initialising VSKEditor plugin")
 
@@ -41,8 +43,12 @@ func _enter_tree() -> void:
 	_uro_toolbar = preload("vsk_editor_uro_toolbar_container.tscn").instantiate()
 	add_control_to_container(CONTAINER_TOOLBAR, _uro_toolbar)
 
+	_editor_interface = Engine.get_singleton("EditorInterface")
+	if not _editor_interface:
+		push_error("EditorInterface singleton is not available")
+		return
 	vsk_editor.setup_editor(
-		EditorInterface.get_editor_main_screen(), _uro_toolbar, get_editor_interface()
+		_editor_interface.get_editor_main_screen(), _uro_toolbar
 	)
 
 func _exit_tree() -> void:

--- a/addons/vsk_editor/vsk_editor_upload_dialog_test.gd
+++ b/addons/vsk_editor/vsk_editor_upload_dialog_test.gd
@@ -22,7 +22,7 @@ func _on_ShowDialogButton_pressed():
 func _ready():
 	var vsk_editor: Node = get_node_or_null("/root/VSKEditor")
 	if vsk_editor:
-		vsk_editor.setup_editor(self, null, null)
+		vsk_editor.setup_editor(self, null)
 	else:
 		push_error("Could not load VSKEditor")
 

--- a/addons/vsk_importer_exporter/vsk_importer_exporter_plugin.gd
+++ b/addons/vsk_importer_exporter/vsk_importer_exporter_plugin.gd
@@ -7,7 +7,7 @@
 extends EditorPlugin
 class_name VSKImporterExporterPlugin
 
-var editor_interface: EditorInterface = null
+var editor_interface = null # EditorInterface
 
 
 func _init():

--- a/project.godot
+++ b/project.godot
@@ -274,4 +274,5 @@ openxr/default_action_map="res://addons/vsk_game_framework/config/vsk_openxr_act
 openxr/extensions/hand_tracking=true
 openxr/extensions/hand_interaction_profile=true
 openxr/extensions/eye_gaze_interaction=true
+openxr/startup_alert=false
 shaders/enabled=true


### PR DESCRIPTION
- Fix EditorInterface crash in exported releases on default game scene load. Static EditorInterface references are replaced by runtime `Engine.get_singleton`
(see [Scripts fail to load with a parse error on exported projects if it uses editor classes](https://www.github.com/godotengine/godot/issues/91713))
Needs in-editor testing. 
- Disabled `missing OpenXR interface` popup warning when starting in flat screen mode.