### PR TITLE
Fix jump applying multiple times

### DIFF
--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_jump_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_jump_component_3d.gd
@@ -6,6 +6,7 @@ class_name SarSimulationComponentJump3D
 ## handling basic jumping behaviour.
 
 var _movement_component: SarGameEntityComponentVesselMovementCharacter3D = null
+var _jump_consumed: bool = false
 
 func _physics_process(_delta: float) -> void:
 	if not Engine.is_editor_hint():
@@ -15,8 +16,11 @@ func _physics_process(_delta: float) -> void:
 			return
 
 		if _movement_component.is_grounded():
-			if should_jump:
+			if should_jump and not _jump_consumed:
 				_movement_component.set_velocity(_movement_component.get_velocity() + (_movement_component.get_up_direction() * jump_velocity))
+				_jump_consumed = true
+		else:
+			_jump_consumed = false
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():

--- a/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_motor_component_3d.gd
+++ b/addons/sar_game_framework/3d/simulation/sar_player_simulation_character_motor_component_3d.gd
@@ -61,13 +61,16 @@ func _process_movement(p_delta: float, p_movement_vector: Vector2) -> void:
 		return
 
 	_current_velocity = _movement_component.get_velocity()
-	
+
+	var vertical_speed: float = _current_velocity.dot(_movement_component.get_up_direction())
+	var horizontal_velocity: Vector3 = _current_velocity - (_movement_component.get_up_direction() * vertical_speed)
+
 	if _movement_component.is_grounded():
-		_current_velocity = _ground_movement(_current_velocity, desired_direction, p_delta)
-		_current_velocity *= (_movement_component.get_horizontal_plane())
+		horizontal_velocity = _ground_movement(horizontal_velocity, desired_direction, p_delta)
 	else:
-		_current_velocity -= (_movement_component.get_up_direction() * _gravity) * p_delta
+		vertical_speed -= _gravity * p_delta
 				
+	_current_velocity = horizontal_velocity + (_movement_component.get_up_direction() * vertical_speed)
 	_movement_component.set_velocity(_current_velocity)
 		
 func _physics_process(p_delta: float) -> void:


### PR DESCRIPTION
Jumps applies every frame that is_grounded() is true, however is_grounded() seems to lag behind a frame even after leaving the ground, which typically results in you getting two applications of upwards momentum.

Can test this erroneous behavior by tapping space for one frame: results in a small jump.

This fix just ensures that we only apply upward velocity once per jump action, and do not allow it again until grounded once more.

Also included is a small fix for the motor component squashing Y movement when it thinks we're grounded (snapping is handled elsewhere anyway).

Preface to some larger motor changes hopefully.